### PR TITLE
Add setFont() family to String and ColumnString PickerPopover

### DIFF
--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.2.1</string>
+	<string>5.3</string>
 	<key>CFBundleVersion</key>
-	<string>521</string>
+	<string>530</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.3</string>
+	<string>6.0</string>
 	<key>CFBundleVersion</key>
-	<string>530</string>
+	<string>600</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Demo/SampleViewController.swift
+++ b/Demo/SampleViewController.swift
@@ -32,6 +32,8 @@ class SampleViewController: UIViewController, UICollectionViewDataSource, UIColl
         /// Create StringPickerPopover:
         let p = StringPickerPopover(title: "StringPicker", choices: ["value 1","value 2","value 3"])
             .setDisplayStringFor(displayStringFor)
+            .setFont(UIFont.boldSystemFont(ofSize: 14))
+            .setFontColor(.blue)
             .setDoneButton(
                 action: {  popover, selectedRow, selectedString in
                 print("done row \(selectedRow) \(selectedString)")
@@ -118,7 +120,8 @@ class SampleViewController: UIViewController, UICollectionViewDataSource, UIColl
                                   selectedRows: [0,0], columnPercents: [0.5, 0.5])
         .setDoneButton(action: { popover, selectedRows, selectedStrings in print("selected rows \(selectedRows) strings \(selectedStrings)")})
         .setCancelButton(action: { _,_,_ in print("cancel")})
-        .setFontSize(14)
+        .setFont(UIFont.boldSystemFont(ofSize: 14))
+        .setFontColor(.brown)
         .appear(originView: sender, baseViewController: self)
     }
 

--- a/Demo/SampleViewController.swift
+++ b/Demo/SampleViewController.swift
@@ -120,8 +120,8 @@ class SampleViewController: UIViewController, UICollectionViewDataSource, UIColl
                                   selectedRows: [0,0], columnPercents: [0.5, 0.5])
         .setDoneButton(action: { popover, selectedRows, selectedStrings in print("selected rows \(selectedRows) strings \(selectedStrings)")})
         .setCancelButton(action: { _,_,_ in print("cancel")})
-        .setFont(UIFont.boldSystemFont(ofSize: 14))
-        .setFontColor(.brown)
+        .setFonts([UIFont.boldSystemFont(ofSize: 14), nil])
+        .setFontColors([nil, .red])
         .appear(originView: sender, baseViewController: self)
     }
 

--- a/Demo/SampleViewController.swift
+++ b/Demo/SampleViewController.swift
@@ -122,6 +122,7 @@ class SampleViewController: UIViewController, UICollectionViewDataSource, UIColl
         .setCancelButton(action: { _,_,_ in print("cancel")})
         .setFonts([UIFont.boldSystemFont(ofSize: 14), nil])
         .setFontColors([nil, .red])
+        .setSelectedRows([0,2])
         .appear(originView: sender, baseViewController: self)
     }
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ All popovers have the following APIs.
 #### StringPickerPopover
 * init(title:, choices:)
 
+* setFont()
+* setFontSize()
+* setFontColor()
 * setImageNames()
 * setImages()
 * setSelectedRow()
@@ -183,11 +186,13 @@ p.appear(originView: originView, baseViewController: self)
 #### ColumnStringPickerPopover
 * init(title:, choices:, selectedRows:, columnPercents:)
 
+* setFonts()
+* setFontSizes()
+* setFontColors()
 * setSelectedRows()
-* setFontSize()
 * setDisplayStringFor()
 * setDoneButton(title:, color:, action:)
-* vButton(title:, color:, action:)
+* setCancelButton(title:, color:, action:)
 
 ##### ColumnStringPickerPopover can have multiple String values:
 ```swift

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ When you prepare your customized Storyboard, it will be applied automatically.
 - BalestraPatrick [GitHub](https://github.com/BalestraPatrick) for README.md typo.
 - andersonlucasg3 [GitHub](https://github.com/andersonlucasg3) for adding possibility to override the storyboards with custom localizations in the app project.
 - Mihael Isaev [GitHub](https://github.com/MihaelIsaev) for adding appear() from barButtonItem.
+- iosMaher [GitHub](https://github.com/iosMaher) for idea of setFont() and setFontColor().
 
 ## Author
 - Yuta Hoshino [Twitter](https://twitter.com/hsylife) [Facebook](https://www.facebook.com/yuta.hoshino)

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -36,9 +36,12 @@ public class ColumnStringPickerPopover: AbstractPopover {
     var selectedRows_: [Int] = [Int]()
     /// Column ratio
     var columnPercents_: [Float] = [Float]()
-    /// Font size
+    ///Font
+    private var font_: UIFont?
     var fontSize_: CGFloat = 12.0
-    
+    ///Font Color
+    private var fontColor_: UIColor = .black
+
     /// Convert a raw value to the string for displaying it
     var displayStringFor_: DisplayStringForType?
     
@@ -127,6 +130,24 @@ public class ColumnStringPickerPopover: AbstractPopover {
         return self
     }
     
+    /// Set font
+    ///
+    /// - Parameter fontName: UIFont to change picker font
+    /// - Returns: Self
+    public func setFont(_ fontName:UIFont) ->Self {
+        self.font_ = fontName
+        return self
+    }
+    
+    /// Set pickerFontColor
+    ///
+    /// - Parameter colorName: UIColor to change picker ArrayColor
+    /// - Returns: Self
+    public func setFontColor(_ colorName:UIColor) ->Self {
+        self.fontColor_ = colorName
+        return self
+    }
+    
     /// Set font size
     ///
     /// - Parameter fontSize: Font size on picker
@@ -135,9 +156,6 @@ public class ColumnStringPickerPopover: AbstractPopover {
         self.fontSize_ = fontSize
         return self
     }
-
-    
-
 }
 
 // MARK: - UIPickerViewDelegate
@@ -153,7 +171,7 @@ extension ColumnStringPickerPopover: UIPickerViewDelegate{
         }
         
         let data = choices[component][row]
-        let title = NSAttributedString(string: data, attributes: [NSAttributedStringKey.font: UIFont.systemFont(ofSize: fontSize_, weight: UIFont.Weight.regular)])
+        let title = NSAttributedString(string: data, attributes: [NSAttributedStringKey.font: font_ ?? UIFont.systemFont(ofSize: fontSize_, weight: UIFont.Weight.regular), NSAttributedStringKey.foregroundColor: fontColor_])
         label!.attributedText = title
         label!.textAlignment = .center
         return label!

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -47,9 +47,9 @@ public class ColumnStringPickerPopover: AbstractPopover {
     private var displayStringFor: DisplayStringForType?
     
     /// Done button parameters
-    private(set) var doneButton: ButtonParameterType = ("Done".localized, nil, nil)
+    private(set) var doneButton: ButtonParameterType = (title:"Done".localized, color: nil, action: nil)
     /// Cancel button parameters
-    private(set) var cancelButton: ButtonParameterType = ("Cancel".localized, nil, nil)
+    private(set) var cancelButton: ButtonParameterType = (title:"Cancel".localized, color: nil, action: nil)
 
     // MARK: - Initializer
     
@@ -120,7 +120,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     ///   - color: Button tintcolor
     ///   - action: Action to be performed before the popover disappeared.
     /// - Returns: Self
-    func setButton( button: inout ButtonParameterType, title:String? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
+    func setButton(button: inout ButtonParameterType, title:String? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
         if let t = title{
             button.title = t
         }
@@ -152,26 +152,20 @@ public class ColumnStringPickerPopover: AbstractPopover {
 
 // MARK: - UIPickerViewDelegate
 extension ColumnStringPickerPopover: UIPickerViewDelegate{
-    public func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return choice(component: component, row: row)
-    }
-    
     public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        var label = view as! UILabel!
-        if label == nil {
-            label = UILabel()
-        }
+        let label:UILabel = view as? UILabel ?? UILabel()
         
-        let data = choices[component][row]
-        label!.text = choice(component: component, row: row)
+        let title = choices[component][row]
+        label.text = choice(component: component, row: row)
         
         let fontSize: CGFloat = fontSizes?[component] ?? kDefaultFontSize
         let font: UIFont = fonts?[component] ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular)
         let fontColor: UIColor = fontColors?[component] ?? kDefaultFontColor
-        let title = NSAttributedString(string: data, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: fontColor])
-        label!.attributedText = title
-        label!.textAlignment = .center
-        return label!
+        let attributedTitle = NSAttributedString(string: title, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: fontColor])
+        label.attributedText = attributedTitle
+        
+        label.textAlignment = .center
+        return label
     }
     
     public func pickerView(_ pickerView: UIPickerView,
@@ -179,7 +173,6 @@ extension ColumnStringPickerPopover: UIPickerViewDelegate{
                            inComponent component: Int){
         
         selectedRows[component] = row
-        
         redoDisappearAutomatically()
     }
 
@@ -206,10 +199,7 @@ extension ColumnStringPickerPopover: UIPickerViewDataSource{
     
     // get string of choice
     func choice(component: Int, row: Int)->ItemType? {
-        if let d = displayStringFor {
-            return d(choices[component][row])
-        }
-        return choices[component][row]
+       return displayStringFor?(choices[component][row]) ?? choices[component][row]
     }
     
     // get array of selected values

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -31,23 +31,23 @@ public class ColumnStringPickerPopover: AbstractPopover {
     // MARK: - Properties
 
     /// Choice array. Nest.
-    private(set)  var choices: [[ItemType]] = [[]]
+    private(set) var choices: [[ItemType]] = [[]]
     /// Selected rows
-    private(set)  var selectedRows_: [Int] = [Int]()
+    private(set) var selectedRows: [Int] = [Int]()
     /// Column ratio
-    private(set)  var columnPercents_: [Float] = [Float]()
+    private(set) var columnPercents: [Float] = [Float]()
     ///Font
-    private(set)  var font_: UIFont?
-    private(set)  var fontSize_: CGFloat = 12
-    private(set)  var fontColor_: UIColor = .black
+    private(set) var font: UIFont?
+    private(set) var fontSize: CGFloat = 12
+    private(set) var fontColor: UIColor = .black
 
     /// Convert a raw value to the string for displaying it
-    private var displayStringFor_: DisplayStringForType?
+    private var displayStringFor: DisplayStringForType?
     
     /// Done button parameters
-    private(set) var doneButton_: ButtonParameterType = ("Done".localized, nil, nil)
+    private(set) var doneButton: ButtonParameterType = ("Done".localized, nil, nil)
     /// Cancel button parameters
-    private(set) var cancelButton_: ButtonParameterType = ("Cancel".localized, nil, nil)
+    private(set) var cancelButton: ButtonParameterType = ("Cancel".localized, nil, nil)
 
     // MARK: - Initializer
     
@@ -64,8 +64,8 @@ public class ColumnStringPickerPopover: AbstractPopover {
         // Set parameters
         self.title = title
         self.choices = choices
-        self.selectedRows_ = selectedRows
-        self.columnPercents_ = columnPercents
+        self.selectedRows = selectedRows
+        self.columnPercents = columnPercents
     }
 
     // MARK: - Propery setter
@@ -75,7 +75,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// - Parameter row: Selected rows of picker
     /// - Returns: Self
     public func setSelectedRows(_ rows:[Int])->Self{
-        self.selectedRows_ = rows
+        self.selectedRows = rows
         return self
     }
     
@@ -84,7 +84,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// - Parameter displayStringFor: Rules for converting choice values to display strings.
     /// - Returns: Self
     public func setDisplayStringFor(_ displayStringFor:DisplayStringForType?)->Self{
-        self.displayStringFor_ = displayStringFor
+        self.displayStringFor = displayStringFor
         return self
     }
 
@@ -96,7 +96,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     ///   - action: Action to be performed before the popover disappeared.
     /// - Returns: Self
     public func setDoneButton(title:String? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
-        return setButton(button: &doneButton_, title:title, color:color, action: action)
+        return setButton(button: &doneButton, title:title, color:color, action: action)
     }
     
     /// Set cancel button properties.
@@ -107,7 +107,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     ///   - action: Action to be performed before the popover disappeared.
     /// - Returns: Self
     public func setCancelButton(title:String? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
-        return setButton(button: &cancelButton_, title:title, color:color, action: action)
+        return setButton(button: &cancelButton, title:title, color:color, action: action)
     }
 
     /// Set button arguments to the targeted button propertoes
@@ -134,7 +134,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// - Parameter fontName: UIFont to change picker font
     /// - Returns: Self
     public func setFont(_ fontName:UIFont) ->Self {
-        self.font_ = fontName
+        self.font = fontName
         return self
     }
     
@@ -143,7 +143,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// - Parameter colorName: UIColor to change picker ArrayColor
     /// - Returns: Self
     public func setFontColor(_ colorName:UIColor) ->Self {
-        self.fontColor_ = colorName
+        self.fontColor = colorName
         return self
     }
     
@@ -152,7 +152,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// - Parameter fontSize: Font size on picker
     /// - Returns: Self
     public func setFontSize(_ fontSize:CGFloat)->Self{
-        self.fontSize_ = fontSize
+        self.fontSize = fontSize
         return self
     }
 }
@@ -170,7 +170,7 @@ extension ColumnStringPickerPopover: UIPickerViewDelegate{
         }
         
         let data = choices[component][row]
-        let title = NSAttributedString(string: data, attributes: [NSAttributedStringKey.font: font_ ?? UIFont.systemFont(ofSize: fontSize_, weight: UIFont.Weight.regular), NSAttributedStringKey.foregroundColor: fontColor_])
+        let title = NSAttributedString(string: data, attributes: [NSAttributedStringKey.font: font ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular), NSAttributedStringKey.foregroundColor: fontColor])
         label!.attributedText = title
         label!.textAlignment = .center
         return label!
@@ -180,7 +180,7 @@ extension ColumnStringPickerPopover: UIPickerViewDelegate{
                            didSelectRow row: Int,
                            inComponent component: Int){
         
-        selectedRows_[component] = row
+        selectedRows[component] = row
         
         redoDisappearAutomatically()
     }
@@ -202,13 +202,13 @@ extension ColumnStringPickerPopover: UIPickerViewDataSource{
     public func pickerView(_ pickerView: UIPickerView,
                            widthForComponent component: Int) -> CGFloat {
         let width = Float(pickerView.frame.size.width)
-        let temp = width * columnPercents_[component]
+        let temp = width * columnPercents[component]
         return CGFloat(temp)
     }
     
     // get string of choice
     func choice(component: Int, row: Int)->ItemType? {
-        if let d = displayStringFor_ {
+        if let d = displayStringFor {
             return d(choices[component][row])
         }
         return choices[component][row]
@@ -217,7 +217,7 @@ extension ColumnStringPickerPopover: UIPickerViewDataSource{
     // get array of selected values
     func selectedValues()->[ItemType]{
         var result = [ItemType]()
-        for (index, content) in selectedRows_.enumerated() {
+        for (index, content) in selectedRows.enumerated() {
             if let string = choice(component: index, row: content){
                 result.append(string)
             }

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -31,24 +31,23 @@ public class ColumnStringPickerPopover: AbstractPopover {
     // MARK: - Properties
 
     /// Choice array. Nest.
-    var choices: [[ItemType]] = [[]]
+    private(set)  var choices: [[ItemType]] = [[]]
     /// Selected rows
-    var selectedRows_: [Int] = [Int]()
+    private(set)  var selectedRows_: [Int] = [Int]()
     /// Column ratio
-    var columnPercents_: [Float] = [Float]()
+    private(set)  var columnPercents_: [Float] = [Float]()
     ///Font
-    private var font_: UIFont?
-    var fontSize_: CGFloat = 12.0
-    ///Font Color
-    private var fontColor_: UIColor = .black
+    private(set)  var font_: UIFont?
+    private(set)  var fontSize_: CGFloat = 12
+    private(set)  var fontColor_: UIColor = .black
 
     /// Convert a raw value to the string for displaying it
-    var displayStringFor_: DisplayStringForType?
+    private var displayStringFor_: DisplayStringForType?
     
     /// Done button parameters
-    var doneButton_: ButtonParameterType = ("Done".localized, nil, nil)
+    private(set) var doneButton_: ButtonParameterType = ("Done".localized, nil, nil)
     /// Cancel button parameters
-    var cancelButton_: ButtonParameterType = ("Cancel".localized, nil, nil)
+    private(set) var cancelButton_: ButtonParameterType = ("Cancel".localized, nil, nil)
 
     // MARK: - Initializer
     

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -37,9 +37,11 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// Column ratio
     private(set) var columnPercents: [Float] = [Float]()
     ///Font
-    private(set) var font: UIFont?
-    private(set) var fontSize: CGFloat = 12
-    private(set) var fontColor: UIColor = .black
+    private(set) var fonts: [UIFont?]?
+    private(set) var fontSizes: [CGFloat?]?
+    private let kDefaultFontSize:CGFloat = 12
+    private(set) var fontColors: [UIColor?]?
+    private let kDefaultFontColor: UIColor = .black
 
     /// Convert a raw value to the string for displaying it
     private var displayStringFor: DisplayStringForType?
@@ -129,30 +131,21 @@ public class ColumnStringPickerPopover: AbstractPopover {
         return self
     }
     
-    /// Set font
-    ///
-    /// - Parameter fontName: UIFont to change picker font
-    /// - Returns: Self
-    public func setFont(_ fontName:UIFont) ->Self {
-        self.font = fontName
+    /// Set fonts
+    public func setFonts(_ fonts:[UIFont?]) ->Self {
+        self.fonts = fonts
         return self
     }
     
-    /// Set pickerFontColor
-    ///
-    /// - Parameter colorName: UIColor to change picker ArrayColor
-    /// - Returns: Self
-    public func setFontColor(_ colorName:UIColor) ->Self {
-        self.fontColor = colorName
+    /// Set pickerFontColors
+    public func setFontColors(_ colors:[UIColor?]) ->Self {
+        self.fontColors = colors
         return self
     }
     
-    /// Set font size
-    ///
-    /// - Parameter fontSize: Font size on picker
-    /// - Returns: Self
-    public func setFontSize(_ fontSize:CGFloat)->Self{
-        self.fontSize = fontSize
+    /// Set font sizes
+    public func setFontSizes(_ fontSizes:[CGFloat?])->Self{
+        self.fontSizes = fontSizes
         return self
     }
 }
@@ -170,7 +163,10 @@ extension ColumnStringPickerPopover: UIPickerViewDelegate{
         }
         
         let data = choices[component][row]
-        let title = NSAttributedString(string: data, attributes: [NSAttributedStringKey.font: font ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular), NSAttributedStringKey.foregroundColor: fontColor])
+        let fontSize: CGFloat = fontSizes?[component] ?? kDefaultFontSize
+        let font: UIFont = fonts?[component] ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular)
+        let fontColor: UIColor = fontColors?[component] ?? kDefaultFontColor
+        let title = NSAttributedString(string: data, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: fontColor])
         label!.attributedText = title
         label!.textAlignment = .center
         return label!

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -163,6 +163,8 @@ extension ColumnStringPickerPopover: UIPickerViewDelegate{
         }
         
         let data = choices[component][row]
+        label!.text = choice(component: component, row: row)
+        
         let fontSize: CGFloat = fontSizes?[component] ?? kDefaultFontSize
         let font: UIFont = fonts?[component] ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular)
         let fontColor: UIColor = fontColors?[component] ?? kDefaultFontColor

--- a/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
@@ -37,28 +37,23 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
         super.refrectPopoverProperties()
         
         // Set up cancel button
-        if #available(iOS 11.0, *) { }
+        if #available(iOS 11.0, *) {}
         else {
             navigationItem.leftBarButtonItem = nil
+            navigationItem.rightBarButtonItem = nil
         }
+        
         cancelButton.title = popover?.cancelButton.title
         cancelButton.tintColor = popover?.cancelButton.color ?? popover?.tintColor
         navigationItem.setLeftBarButton(cancelButton, animated: false)
 
-        // Set up done button
-        if #available(iOS 11.0, *) { }
-        else {
-            navigationItem.rightBarButtonItem = nil
-        }
         doneButton.title = popover?.doneButton.title
         doneButton.tintColor = popover?.doneButton.color ?? popover?.tintColor
         navigationItem.setRightBarButton(doneButton, animated: false)
 
         // Select row if needed
-        if let selected = popover?.selectedRows {
-            for x in 0..<selected.count {
-                picker.selectRow(selected[x], inComponent: x, animated: true)
-            }
+        popover?.selectedRows.enumerated().forEach {
+            picker.selectRow($0.1, inComponent: $0.0, animated: true)
         }
     }
     
@@ -66,26 +61,22 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
     ///
     /// - Parameter sender: Done button
     @IBAction func tappedDone(_ sender: AnyObject? = nil) {
-        if let popover = popover {
-            let selectedRows = popover.selectedRows
-            let selectedChoices = popover.selectedValues()
-            popover.doneButton.action?(popover, selectedRows, selectedChoices)
-            
-            dismiss(animated: false, completion: {})
-        }
+        tapped(button: popover?.doneButton)
     }
     
     /// Action when tapping cancel button
     ///
     /// - Parameter sender: Cancel button
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
-        if let popover = popover {
-            let selectedRows = popover.selectedRows
-            let selectedChoices = popover.selectedValues()
-            popover.cancelButton.action?(popover, selectedRows, selectedChoices)
-            
-            dismiss(animated: false, completion: {})
-        }
+        tapped(button: popover?.cancelButton)
+    }
+    
+    private func tapped(button: ColumnStringPickerPopover.ButtonParameterType?) {
+        guard let popover = popover else { return }
+        let selectedRows = popover.selectedRows
+        let selectedChoices = popover.selectedValues()
+        button?.action?(popover, selectedRows, selectedChoices)
+        dismiss(animated: false, completion: {})
     }
     
     /// Action to be executed after the popover disappears

--- a/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
@@ -41,8 +41,8 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
         else {
             navigationItem.leftBarButtonItem = nil
         }
-        cancelButton.title = popover?.cancelButton_.title
-        cancelButton.tintColor = popover?.cancelButton_.color ?? popover?.tintColor
+        cancelButton.title = popover?.cancelButton.title
+        cancelButton.tintColor = popover?.cancelButton.color ?? popover?.tintColor
         navigationItem.setLeftBarButton(cancelButton, animated: false)
 
         // Set up done button
@@ -50,12 +50,12 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
         else {
             navigationItem.rightBarButtonItem = nil
         }
-        doneButton.title = popover?.doneButton_.title
-        doneButton.tintColor = popover?.doneButton_.color ?? popover?.tintColor
+        doneButton.title = popover?.doneButton.title
+        doneButton.tintColor = popover?.doneButton.color ?? popover?.tintColor
         navigationItem.setRightBarButton(doneButton, animated: false)
 
         // Select row if needed
-        if let selected = popover?.selectedRows_ {
+        if let selected = popover?.selectedRows {
             for x in 0..<selected.count {
                 picker.selectRow(selected[x], inComponent: x, animated: true)
             }
@@ -67,9 +67,9 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
     /// - Parameter sender: Done button
     @IBAction func tappedDone(_ sender: AnyObject? = nil) {
         if let popover = popover {
-            let selectedRows = popover.selectedRows_
+            let selectedRows = popover.selectedRows
             let selectedChoices = popover.selectedValues()
-            popover.doneButton_.action?(popover, selectedRows, selectedChoices)
+            popover.doneButton.action?(popover, selectedRows, selectedChoices)
             
             dismiss(animated: false, completion: {})
         }
@@ -80,9 +80,9 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
     /// - Parameter sender: Cancel button
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
         if let popover = popover {
-            let selectedRows = popover.selectedRows_
+            let selectedRows = popover.selectedRows
             let selectedChoices = popover.selectedValues()
-            popover.cancelButton_.action?(popover, selectedRows, selectedChoices)
+            popover.cancelButton.action?(popover, selectedRows, selectedChoices)
             
             dismiss(animated: false, completion: {})
         }

--- a/SwiftyPickerPopover/Info.plist
+++ b/SwiftyPickerPopover/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.3.0</string>
+	<string>6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -31,6 +31,12 @@ public class StringPickerPopover: AbstractPopover {
     /// Array of image to attach to a choice
     var images_: [UIImage?]?
     
+    /// Font
+    private var font_: UIFont?
+    
+    /// Font color
+    private var fontColor_: UIColor?
+    
     /// Convert a raw value to the string for displaying it
     var displayStringFor_:DisplayStringForType?
     
@@ -61,6 +67,24 @@ public class StringPickerPopover: AbstractPopover {
         
     }
 
+    /// Set font
+    ///
+    /// - Parameter fontName: UIFont to change picker font
+    /// - Returns: Self
+    public func setFont(_ fontName:UIFont) ->Self {
+        self.font_ = fontName
+        return self
+    }
+    
+    /// Set pickerFontColor
+    ///
+    /// - Parameter colorName: UIColor to change picker ArrayColor
+    /// - Returns: Self
+    public func setColor(_ colorName:UIColor) ->Self {
+        self.fontColor_ = colorName
+        return self
+    }
+    
     // MARK: - Propery setter
 
     /// Set image names
@@ -218,6 +242,15 @@ extension StringPickerPopover: UIPickerViewDelegate {
         return baseAtt
     }
 
+    public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        let pickerLabel = (view as? UILabel) ?? UILabel()
+        pickerLabel.textColor = fontColor_ ?? .black
+        pickerLabel.textAlignment = .center
+        pickerLabel.font = self.font_ ?? UIFont.systemFont(ofSize: 15)
+        pickerLabel.text = choices[row]
+        return pickerLabel
+    }
+    
     public func pickerView(_ pickerView: UIPickerView,
                            rowHeightForComponent component: Int) -> CGFloat {
         return rowHeight_

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -35,7 +35,7 @@ public class StringPickerPopover: AbstractPopover {
     private var font_: UIFont?
     
     /// Font color
-    private var fontColor_: UIColor?
+    private var fontColor_: UIColor = .black
     
     /// Convert a raw value to the string for displaying it
     var displayStringFor_:DisplayStringForType?
@@ -244,7 +244,7 @@ extension StringPickerPopover: UIPickerViewDelegate {
 
     public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
         let pickerLabel = (view as? UILabel) ?? UILabel()
-        pickerLabel.textColor = fontColor_ ?? .black
+        pickerLabel.textColor = fontColor_
         pickerLabel.textAlignment = .center
         pickerLabel.font = self.font_ ?? UIFont.systemFont(ofSize: 15)
         pickerLabel.text = choices[row]

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -71,8 +71,8 @@ public class StringPickerPopover: AbstractPopover {
     ///
     /// - Parameter fontName: UIFont to change picker font
     /// - Returns: Self
-    public func setFont(_ fontName:UIFont) ->Self {
-        self.font_ = fontName
+    public func setFont(_ font:UIFont) ->Self {
+        self.font_ = font
         return self
     }
     
@@ -80,8 +80,8 @@ public class StringPickerPopover: AbstractPopover {
     ///
     /// - Parameter colorName: UIColor to change picker ArrayColor
     /// - Returns: Self
-    public func setColor(_ colorName:UIColor) ->Self {
-        self.fontColor_ = colorName
+    public func setFontColor(_ color:UIColor) ->Self {
+        self.fontColor_ = color
         return self
     }
     

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -25,31 +25,29 @@ public class StringPickerPopover: AbstractPopover {
     // MARK: - Properties
     
     /// Choice array
-    var choices: [ItemType] = []
+    private(set) var choices: [ItemType] = []
     /// Array of image name to attach to a choice
-    var imageNames_: [String?]?
+    private(set) var imageNames: [String?]?
     /// Array of image to attach to a choice
-    var images_: [UIImage?]?
+    private(set) var images: [UIImage?]?
     
     /// Font
-    private var font_: UIFont?
-    
-    /// Font color
-    private var fontColor_: UIColor = .black
+    private(set)  var font: UIFont?
+    private(set)  var fontColor: UIColor = .black
     
     /// Convert a raw value to the string for displaying it
-    var displayStringFor_:DisplayStringForType?
+    private(set) var displayStringFor: DisplayStringForType?
     
     /// Done button parameters
-    var doneButton_: ButtonParameterType = ("Done".localized, nil, nil)
+    private(set) var doneButton: ButtonParameterType = ("Done".localized, nil, nil)
     /// Cancel button parameters
-    var cancelButton_: ButtonParameterType = ("Cancel".localized, nil, nil)
+    private(set) var cancelButton: ButtonParameterType = ("Cancel".localized, nil, nil)
     
     /// Selected row
-    var selectedRow_: Int = 0
+    private(set) var selectedRow: Int = 0
 
     /// Row height
-    var rowHeight_: CGFloat = 44.0
+    private(set) var rowHeight: CGFloat = 44
     
     // MARK: - Initializer
 
@@ -72,7 +70,7 @@ public class StringPickerPopover: AbstractPopover {
     /// - Parameter fontName: UIFont to change picker font
     /// - Returns: Self
     public func setFont(_ font:UIFont) ->Self {
-        self.font_ = font
+        self.font = font
         return self
     }
     
@@ -81,7 +79,7 @@ public class StringPickerPopover: AbstractPopover {
     /// - Parameter colorName: UIColor to change picker ArrayColor
     /// - Returns: Self
     public func setFontColor(_ color:UIColor) ->Self {
-        self.fontColor_ = color
+        self.fontColor = color
         return self
     }
     
@@ -92,7 +90,7 @@ public class StringPickerPopover: AbstractPopover {
     /// - Parameter imageNames: String Array of image name to attach to a choice
     /// - Returns: Self
     public func setImageNames(_ imageNames:[String?]?)->Self{
-        self.imageNames_ = imageNames
+        self.imageNames = imageNames
         return self
     }
 
@@ -101,7 +99,7 @@ public class StringPickerPopover: AbstractPopover {
     /// - Parameter images: String Array of image to attach to a choice
     /// - Returns: Self
     public func setImages(_ images:[UIImage?]?)->Self{
-        self.images_ = images
+        self.images = images
         return self
     }
     
@@ -110,7 +108,7 @@ public class StringPickerPopover: AbstractPopover {
     /// - Parameter row: Selected row on picker
     /// - Returns: Self
     public func setSelectedRow(_ row:Int)->Self{
-        self.selectedRow_ = row
+        self.selectedRow = row
         return self
     }
 
@@ -119,7 +117,7 @@ public class StringPickerPopover: AbstractPopover {
     /// - Parameter height: Row height
     /// - Returns: Self
     public func setRowHeight(_ height:CGFloat)->Self{
-        self.rowHeight_ = height
+        self.rowHeight = height
         return self
     }
     
@@ -128,7 +126,7 @@ public class StringPickerPopover: AbstractPopover {
     /// - Parameter displayStringFor: Rules for converting choice values to display strings.
     /// - Returns: Self
     public func setDisplayStringFor(_ displayStringFor:DisplayStringForType?)->Self{
-        self.displayStringFor_ = displayStringFor
+        self.displayStringFor = displayStringFor
         return self
     }
     
@@ -140,7 +138,7 @@ public class StringPickerPopover: AbstractPopover {
     ///   - action: Action to be performed before the popover disappeared. The popover, Selected row, Selected value. Omissble.
     /// - Returns: Self
     public func setDoneButton(title:String? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
-        return setButton(button: &doneButton_, title:title, color:color, action: action)
+        return setButton(button: &doneButton, title:title, color:color, action: action)
 
     }
 
@@ -152,7 +150,7 @@ public class StringPickerPopover: AbstractPopover {
     ///   - action: Action to be performed before the popover disappeared.The popover, Selected row, Selected value.
     /// - Returns: Self
     public func setCancelButton(title:String? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
-        return setButton(button: &cancelButton_, title:title, color:color, action: action)
+        return setButton(button: &cancelButton, title:title, color:color, action: action)
     }
     
     /// Set button arguments to the targeted button propertoes
@@ -190,7 +188,7 @@ extension StringPickerPopover: UIPickerViewDataSource {
 // MARK: - UIPickerViewDelegate
 extension StringPickerPopover: UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        if let d = displayStringFor_ {
+        if let d = displayStringFor {
             return d(choices[row])
         }
         return choices[row]
@@ -199,7 +197,7 @@ extension StringPickerPopover: UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
         let baseAtt = NSMutableAttributedString()
         
-        if let imageNames = imageNames_{
+        if let imageNames = imageNames{
             if let name = imageNames[row], let image = UIImage(named: name){
                 
                 let imageAttachment = NSTextAttachment()
@@ -214,7 +212,7 @@ extension StringPickerPopover: UIPickerViewDelegate {
                 return nil
             }
         }
-        else if let images = images_ {
+        else if let images = images {
             if let image = images[row] {
                 
                 let imageAttachment = NSTextAttachment()
@@ -232,7 +230,7 @@ extension StringPickerPopover: UIPickerViewDelegate {
         }
         
         var str:String?
-        if let d = displayStringFor_ {
+        if let d = displayStringFor {
             str = d(choices[row])
         }
         
@@ -244,16 +242,16 @@ extension StringPickerPopover: UIPickerViewDelegate {
 
     public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
         let pickerLabel = (view as? UILabel) ?? UILabel()
-        pickerLabel.textColor = fontColor_
+        pickerLabel.textColor = fontColor
         pickerLabel.textAlignment = .center
-        pickerLabel.font = self.font_ ?? UIFont.systemFont(ofSize: 15)
+        pickerLabel.font = self.font ?? UIFont.systemFont(ofSize: 15)
         pickerLabel.text = choices[row]
         return pickerLabel
     }
     
     public func pickerView(_ pickerView: UIPickerView,
                            rowHeightForComponent component: Int) -> CGFloat {
-        return rowHeight_
+        return rowHeight
     }
     
     public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -168,7 +168,7 @@ public class StringPickerPopover: AbstractPopover {
     ///   - color: Button tintcolor
     ///   - action: Action to be performed before the popover disappeared.
     /// - Returns: Self
-    func setButton( button: inout ButtonParameterType, title:String? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
+    func setButton(button: inout ButtonParameterType, title:String? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
         if let t = title{
             button.title = t
         }

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -26,14 +26,13 @@ public class StringPickerPopover: AbstractPopover {
     
     /// Choice array
     private(set) var choices: [ItemType] = []
-    /// Array of image name to attach to a choice
-    private(set) var imageNames: [String?]?
     /// Array of image to attach to a choice
     private(set) var images: [UIImage?]?
     
     /// Font
-    private(set)  var font: UIFont?
-    private(set)  var fontColor: UIColor = .black
+    private(set) var font: UIFont?
+    private(set) var fontColor: UIColor = .black
+    private(set) var fontSize: CGFloat = 12
     
     /// Convert a raw value to the string for displaying it
     private(set) var displayStringFor: DisplayStringForType?
@@ -74,6 +73,11 @@ public class StringPickerPopover: AbstractPopover {
         return self
     }
     
+    public func setFontSize(_ size:CGFloat) -> Self {
+        self.fontSize = size
+        return self
+    }
+    
     /// Set pickerFontColor
     ///
     /// - Parameter colorName: UIColor to change picker ArrayColor
@@ -90,7 +94,10 @@ public class StringPickerPopover: AbstractPopover {
     /// - Parameter imageNames: String Array of image name to attach to a choice
     /// - Returns: Self
     public func setImageNames(_ imageNames:[String?]?)->Self{
-        self.imageNames = imageNames
+        self.images = imageNames?.map({
+            guard let imageName = $0 else { return nil }
+            return UIImage(named: imageName)
+        })
         return self
     }
 
@@ -188,65 +195,28 @@ extension StringPickerPopover: UIPickerViewDataSource {
 // MARK: - UIPickerViewDelegate
 extension StringPickerPopover: UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        if let d = displayStringFor {
-            return d(choices[row])
-        }
-        return choices[row]
+        return displayStringFor?(choices[row]) ?? choices[row]
     }
     
     public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
-        let baseAtt = NSMutableAttributedString()
+        let attributedResult = NSMutableAttributedString()
         
-        if let imageNames = imageNames{
-            if let name = imageNames[row], let image = UIImage(named: name){
-                
-                let imageAttachment = NSTextAttachment()
-                imageAttachment.image = image
-                let imageAtt = NSAttributedString(attachment: imageAttachment)
-                baseAtt.append(imageAtt)
-                
-                let marginAtt = NSAttributedString(string: " ")
-                baseAtt.append(marginAtt)
-            }
-            else {
-                return nil
-            }
+        if let images = images, let image = images[row] {
+            let imageAttachment = NSTextAttachment()
+            imageAttachment.image = image
+            let attributedImage = NSAttributedString(attachment: imageAttachment)
+            attributedResult.append(attributedImage)
+            
+            let AttributedMargin = NSAttributedString(string: " ")
+            attributedResult.append(AttributedMargin)
         }
-        else if let images = images {
-            if let image = images[row] {
-                
-                let imageAttachment = NSTextAttachment()
-                imageAttachment.image = image
-                let imageAtt = NSAttributedString(attachment: imageAttachment)
-                baseAtt.append(imageAtt)
-                
-                let marginAtt = NSAttributedString(string: " ")
-                baseAtt.append(marginAtt)
-            }
-            else {
-                return nil
-            }
+        
+        let title: String = displayStringFor?(choices[row]) ?? choices[row]
+        let font: UIFont = self.font ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular)
+        let attributedTitle = NSAttributedString(string: title, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: fontColor])
 
-        }
-        
-        var str:String?
-        if let d = displayStringFor {
-            str = d(choices[row])
-        }
-        
-        let stringAtt = NSAttributedString(string: str ?? choices[row])
-        baseAtt.append(stringAtt)
-        
-        return baseAtt
-    }
-
-    public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        let pickerLabel = (view as? UILabel) ?? UILabel()
-        pickerLabel.textColor = fontColor
-        pickerLabel.textAlignment = .center
-        pickerLabel.font = self.font ?? UIFont.systemFont(ofSize: 15)
-        pickerLabel.text = choices[row]
-        return pickerLabel
+        attributedResult.append(attributedTitle)
+        return attributedResult
     }
     
     public func pickerView(_ pickerView: UIPickerView,

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -35,16 +35,12 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
         if #available(iOS 11.0, *) { }
         else {
             navigationItem.leftBarButtonItem = nil
+            navigationItem.rightBarButtonItem = nil
         }
         cancelButton.title = popover?.cancelButton.title
         cancelButton.tintColor = popover?.cancelButton.color ?? popover?.tintColor
         navigationItem.setLeftBarButton(cancelButton, animated: false)
         
-        // Set up done button
-        if #available(iOS 11.0, *) { }
-        else {
-            navigationItem.rightBarButtonItem = nil
-        }
         doneButton.title = popover?.doneButton.title
         doneButton.tintColor = popover?.doneButton.color ?? popover?.tintColor
         navigationItem.setRightBarButton(doneButton, animated: false)
@@ -59,20 +55,20 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     ///
     /// - Parameter sender: Done button
     @IBAction func tappedDone(_ sender: AnyObject? = nil) {
-        let selectedRow = picker.selectedRow(inComponent: 0)
-        if let selectedString = popover?.choices[selectedRow]{
-            popover?.doneButton.action?(popover!, selectedRow, selectedString)
-        }
-        dismiss(animated: false, completion: {})
+        tapped(button: popover?.doneButton)
     }
     
     /// Action when tapping cancel button
     ///
     /// - Parameter sender: Cancel button
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
+        tapped(button: popover?.cancelButton)
+    }
+    
+    private func tapped(button: StringPickerPopover.ButtonParameterType?) {
         let selectedRow = picker.selectedRow(inComponent: 0)
-        if let selectedString = popover?.choices[selectedRow]{
-            popover?.cancelButton.action?(popover!, selectedRow, selectedString)
+        if let selectedString = popover?.choices[selectedRow] {
+            button?.action?(popover!, selectedRow, selectedString)
         }
         dismiss(animated: false, completion: {})
     }

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -36,8 +36,8 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
         else {
             navigationItem.leftBarButtonItem = nil
         }
-        cancelButton.title = popover?.cancelButton_.title
-        cancelButton.tintColor = popover?.cancelButton_.color ?? popover?.tintColor
+        cancelButton.title = popover?.cancelButton.title
+        cancelButton.tintColor = popover?.cancelButton.color ?? popover?.tintColor
         navigationItem.setLeftBarButton(cancelButton, animated: false)
         
         // Set up done button
@@ -45,12 +45,12 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
         else {
             navigationItem.rightBarButtonItem = nil
         }
-        doneButton.title = popover?.doneButton_.title
-        doneButton.tintColor = popover?.doneButton_.color ?? popover?.tintColor
+        doneButton.title = popover?.doneButton.title
+        doneButton.tintColor = popover?.doneButton.color ?? popover?.tintColor
         navigationItem.setRightBarButton(doneButton, animated: false)
 
         // Select row if needed
-        if let select = popover?.selectedRow_ {
+        if let select = popover?.selectedRow {
             picker?.selectRow(select, inComponent: 0, animated: true)
         }
     }
@@ -61,7 +61,7 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     @IBAction func tappedDone(_ sender: AnyObject? = nil) {
         let selectedRow = picker.selectedRow(inComponent: 0)
         if let selectedString = popover?.choices[selectedRow]{
-            popover?.doneButton_.action?(popover!, selectedRow, selectedString)
+            popover?.doneButton.action?(popover!, selectedRow, selectedString)
         }
         dismiss(animated: false, completion: {})
     }
@@ -72,7 +72,7 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
         let selectedRow = picker.selectedRow(inComponent: 0)
         if let selectedString = popover?.choices[selectedRow]{
-            popover?.cancelButton_.action?(popover!, selectedRow, selectedString)
+            popover?.cancelButton.action?(popover!, selectedRow, selectedString)
         }
         dismiss(animated: false, completion: {})
     }


### PR DESCRIPTION
**Beckground**
The more customizable, the better.
StringPickerPopover has no setFont(), setFontColor() and setFontSize().
Also, ColumnStringPickerPopover has no setFonts(), setFontColors() and setFontSizes().
They get them all by this PR.

**Modified code**
Added setFont(), setFontColor() and setFontSize() to StringPickerPopover.
Added  setFonts(), setFontColors() and setFontSizes() to ColumnStringPickerPopover. Instead, removed setFontSize().
