### PR TITLE
Feature/issue 89 clear button for string and column string picker popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+6.5.0 Release notes (2018-05-27)
+=============================================================
+
+### API Breaking Changes
+
+* Nothing
+
+### Enhancements
+
+* * Add: setClearButton() to String/ColumnStringPickerPopover.
+
+### Bugfixes
+
+* Fix: setSelectedRow/Rows() don't work correctly.
+
 6.4.0 Release notes (2018-05-24)
 =============================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+6.4.0 Release notes (2018-05-27)
+=============================================================
+
+### API Breaking Changes
+
+* Nothing
+
+### Enhancements
+
+* Add: setClearButton() to String/ColumnStringPickerPopover.
+
+### Bugfixes
+
+* Fix: setSelectedRow/Rows() don't work correctly.
+
 6.3.1 Release notes (2018-05-21)
 =============================================================
 

--- a/Demo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Demo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,14 +18,14 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aVI-Bm-Z6M" userLabel="TitleView">
-                                <rect key="frame" x="0.0" y="20" width="600" height="50"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="68.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SwiftyPickerPopover" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yTw-zc-9na">
-                                        <rect key="frame" x="217.5" y="15" width="166.5" height="20.5"/>
+                                        <rect key="frame" x="105" y="24.5" width="166.5" height="20.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -34,10 +38,10 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="EQM-gH-Hgi">
-                                <rect key="frame" x="0.0" y="70" width="600" height="460"/>
+                                <rect key="frame" x="0.0" y="88.5" width="375" height="490"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="mQR-1B-va6" userLabel="StringPicker Stack View">
-                                        <rect key="frame" x="219" y="0.0" width="162" height="88"/>
+                                        <rect key="frame" x="106.5" y="0.0" width="162" height="118"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h1U-9C-Ihc">
                                                 <rect key="frame" x="39" y="0.0" width="84" height="44"/>
@@ -59,10 +63,17 @@
                                                     <action selector="didTapStringPickerWithImageButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GzE-iy-hjk"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZLL-IA-ugZ" userLabel="StringPicker Clearable">
+                                                <rect key="frame" x="5" y="88" width="152" height="30"/>
+                                                <state key="normal" title="StringPicker Clearable"/>
+                                                <connections>
+                                                    <action selector="didTapStringPickerClearableButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="eCu-rx-nia"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jyN-8C-oCb">
-                                        <rect key="frame" x="200" y="98" width="200" height="32"/>
+                                        <rect key="frame" x="87.5" y="128" width="200" height="32"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="32" id="KBJ-Q8-ZUB"/>
                                             <constraint firstAttribute="width" constant="200" id="ett-0f-LZ7"/>
@@ -75,7 +86,7 @@
                                         </connections>
                                     </textField>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="xb6-im-pvz" userLabel="ColumnStringPicker Stack View">
-                                        <rect key="frame" x="228" y="140" width="144" height="44"/>
+                                        <rect key="frame" x="115.5" y="170" width="144" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dyw-Xo-Who">
                                                 <rect key="frame" x="0.0" y="0.0" width="144" height="44"/>
@@ -90,16 +101,16 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="J9Z-Db-NVm" userLabel="CollectionView Stack View">
-                                        <rect key="frame" x="0.0" y="194" width="600" height="70"/>
+                                        <rect key="frame" x="0.0" y="224" width="375" height="70"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="collectionView" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zpQ-gA-FQa">
-                                                <rect key="frame" x="245" y="0.0" width="110.5" height="24"/>
+                                                <rect key="frame" x="132.5" y="0.0" width="110.5" height="24"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="vW8-VH-ijj">
-                                                <rect key="frame" x="185" y="24" width="230" height="46"/>
+                                                <rect key="frame" x="72.5" y="24" width="230" height="46"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="46" id="bhY-3C-FdY"/>
@@ -112,7 +123,7 @@
                                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                 </collectionViewFlowLayout>
                                                 <cells>
-                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Cell" id="tPz-UL-PSM">
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" reuseIdentifier="Cell" id="tPz-UL-PSM">
                                                         <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -120,7 +131,6 @@
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WGq-v7-9Vx">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -146,7 +156,7 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QZp-iL-6BW" userLabel="DatePicker Stack View">
-                                        <rect key="frame" x="212" y="274" width="176" height="132"/>
+                                        <rect key="frame" x="99.5" y="304" width="176" height="132"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S0f-NN-ctD">
                                                 <rect key="frame" x="0.0" y="0.0" width="176" height="44"/>
@@ -181,7 +191,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="qa5-lZ-Dlo" userLabel="CountdownPicker Stack View">
-                                        <rect key="frame" x="260.5" y="416" width="79" height="44"/>
+                                        <rect key="frame" x="148" y="446" width="79" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r3c-rj-dZy">
                                                 <rect key="frame" x="0.0" y="0.0" width="79" height="44"/>

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.2.0</string>
+	<string>6.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>620</string>
+	<string>640</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Demo/Info.plist
+++ b/Demo/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.0</string>
+	<string>6.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>640</string>
+	<string>650</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Demo/SampleViewController.swift
+++ b/Demo/SampleViewController.swift
@@ -91,8 +91,7 @@ class SampleViewController: UIViewController, UICollectionViewDataSource, UIColl
         .setDoneButton(action: { popover, selectedRow, selectedString in
             sender.text = selectedString
         })
-        .appear(originView: sender, baseViewController: self)
-        
+        .appear(originView: sender, baseViewController: self)        
     }
     
     @IBAction func tappendDatePickerButton(_ sender: UIButton) {

--- a/Demo/SampleViewController.swift
+++ b/Demo/SampleViewController.swift
@@ -68,6 +68,21 @@ class SampleViewController: UIViewController, UICollectionViewDataSource, UIColl
         p.appear(originView: sender, baseViewController: self)
     }
     
+    @IBAction func didTapStringPickerClearableButton(_ sender: UIButton) {
+        /// StringPickerPopover Clearable:
+        let p = StringPickerPopover(title: "Clearable", choices: ["value 1","value 2","value3"])
+            .setDoneButton(color: UIColor.red, action: {
+                popover, selectedRow, selectedString in
+                print("done row \(selectedRow) \(selectedString)")
+            })
+            .setCancelButton(action: {_, _, _ in
+                print("cancel") })
+            .setClearButton(title: "Reset", action: {(popover, row, value) in
+                print("clear")
+            })
+        p.appear(originView: sender, baseViewController: self)
+    }
+    
     @IBAction func didTapStringPickerWithTextField(_ sender: UITextField) {
         StringPickerPopover(title: "TextField", choices: ["","Text 1", "Text 2", "Text 3"])
         .setValueChange(action: { _, _, selectedString in

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ p.appear(originView: originView, baseViewController: self)
 * setDisplayStringFor()
 * setDoneButton(title:, font:, color:, action:)
 * setCancelButton(title:, font:, color:, action:)
+* setClearButton(title:, font:,  color:, action:)
 
 ##### ColumnStringPickerPopover can have multiple String values:
 ```swift

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ All popovers have the following APIs.
 * setDisplayStringFor()
 * setDoneButton(title:, font:, color:, action:)
 * setCancelButton(title:, font:,  color:, action:)
+* setClearButton(title:, font:,  color:, action:)
 
 ##### You can use StringPickerPopover like this:
 ```swift

--- a/SwiftyPickerPopover.podspec
+++ b/SwiftyPickerPopover.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyPickerPopover"
-  s.version      = "6.4.0"
+  s.version      = "6.5.0"
   s.summary      = "A more convenient way to display a popover with a built-in picker, on iPhone/iPad of iOS9+."
   s.homepage     = "https://github.com/hsylife/SwiftyPickerPopover"
   s.license      = "MIT"

--- a/SwiftyPickerPopover.podspec
+++ b/SwiftyPickerPopover.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyPickerPopover"
-  s.version      = "6.3.1"
+  s.version      = "6.4.0"
   s.summary      = "A more convenient way to display a popover with a built-in picker, on iPhone/iPad of iOS9+."
   s.homepage     = "https://github.com/hsylife/SwiftyPickerPopover"
   s.license      = "MIT"

--- a/SwiftyPickerPopover/AbstractPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/AbstractPickerPopoverViewController.swift
@@ -13,7 +13,7 @@ import UIKit
 open class AbstractPickerPopoverViewController: UIViewController {
     
     /// AbstractPopover
-    var anyPopover: AnyObject?
+    var anyPopover: AbstractPopover!
     
     open override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,16 +22,13 @@ open class AbstractPickerPopoverViewController: UIViewController {
     
     /// Make the popover property reflect on the popover
     func refrectPopoverProperties(){
-        guard let popover = anyPopover as? AbstractPopover else {
-            return
-        }
-        title = popover.title
+        title = anyPopover.title
         
         // Change size if needed
-        if let width = popover.size?.width {
+        if let width = anyPopover.size?.width {
             navigationController?.preferredContentSize.width = width
         }
-        if let height = popover.size?.height {
+        if let height = anyPopover.size?.height {
             navigationController?.preferredContentSize.height = height
         }
     }

--- a/SwiftyPickerPopover/AbstractPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/AbstractPickerPopoverViewController.swift
@@ -15,22 +15,24 @@ open class AbstractPickerPopoverViewController: UIViewController {
     /// AbstractPopover
     var anyPopover: AnyObject?
     
-    open override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    open override func viewDidLoad() {
+        super.viewDidLoad()
         refrectPopoverProperties()
     }
     
     /// Make the popover property reflect on the popover
     func refrectPopoverProperties(){
-        title = (anyPopover as? AbstractPopover)?.title
+        guard let popover = anyPopover as? AbstractPopover else {
+            return
+        }
+        title = popover.title
         
         // Change size if needed
-        if let w = (anyPopover as? AbstractPopover)?.size?.width {
-            navigationController?.preferredContentSize.width = w
+        if let width = popover.size?.width {
+            navigationController?.preferredContentSize.width = width
         }
-
-        if let h = (anyPopover as? AbstractPopover)?.size?.height {
-            navigationController?.preferredContentSize.height = h
+        if let height = popover.size?.height {
+            navigationController?.preferredContentSize.height = height
         }
     }
 }

--- a/SwiftyPickerPopover/AbstractPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/AbstractPickerPopoverViewController.swift
@@ -15,8 +15,8 @@ open class AbstractPickerPopoverViewController: UIViewController {
     /// AbstractPopover
     var anyPopover: AbstractPopover!
     
-    open override func viewDidLoad() {
-        super.viewDidLoad()
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         refrectPopoverProperties()
     }
     

--- a/SwiftyPickerPopover/Base.lproj/CountdownPickerPopover.storyboard
+++ b/SwiftyPickerPopover/Base.lproj/CountdownPickerPopover.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.17" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="byJ-Vv-M5N">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="byJ-Vv-M5N">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,7 +16,7 @@
                     <value key="contentSizeForViewInPopover" type="size" width="300" height="300"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="sFP-QF-Beb">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -39,36 +39,37 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4cY-yy-Wau">
-                                <rect key="frame" x="0.0" y="629" width="375" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="PHP-jd-ES9"/>
-                                </constraints>
-                                <state key="normal" title="Clear"/>
-                                <connections>
-                                    <action selector="tappedClear:" destination="erI-yJ-JEk" eventType="touchUpInside" id="cMx-Qs-KEL"/>
-                                </connections>
-                            </button>
-                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="countDownTimer" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="7zB-OQ-P43">
-                                <rect key="frame" x="0.0" y="64" width="375" height="565"/>
-                                <date key="date" timeIntervalSinceReferenceDate="495455736.64444602">
-                                    <!--2016-09-13 10:35:36 +0000-->
-                                </date>
-                                <connections>
-                                    <action selector="pickerValueChanged:" destination="erI-yJ-JEk" eventType="valueChanged" id="jgp-eK-LRd"/>
-                                </connections>
-                            </datePicker>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="0l0-Ib-qwY">
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <subviews>
+                                    <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="countDownTimer" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="7zB-OQ-P43">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="573"/>
+                                        <date key="date" timeIntervalSinceReferenceDate="495455736.64444602">
+                                            <!--2016-09-13 10:35:36 +0000-->
+                                        </date>
+                                        <connections>
+                                            <action selector="pickerValueChanged:" destination="erI-yJ-JEk" eventType="valueChanged" id="jgp-eK-LRd"/>
+                                        </connections>
+                                    </datePicker>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4cY-yy-Wau">
+                                        <rect key="frame" x="0.0" y="573" width="375" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="PHP-jd-ES9"/>
+                                        </constraints>
+                                        <state key="normal" title="Clear"/>
+                                        <connections>
+                                            <action selector="tappedClear:" destination="erI-yJ-JEk" eventType="touchUpInside" id="cMx-Qs-KEL"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="KrY-U2-tGZ" firstAttribute="top" secondItem="7zB-OQ-P43" secondAttribute="bottom" priority="250" constant="8" id="2a2-QC-xR7"/>
-                            <constraint firstItem="4cY-yy-Wau" firstAttribute="leading" secondItem="wcv-6k-DXR" secondAttribute="leading" id="4r5-LO-1ah"/>
-                            <constraint firstAttribute="trailing" secondItem="7zB-OQ-P43" secondAttribute="trailing" id="CcD-Rg-vh1"/>
-                            <constraint firstItem="7zB-OQ-P43" firstAttribute="leading" secondItem="wcv-6k-DXR" secondAttribute="leading" id="Dh6-Ij-o5t"/>
-                            <constraint firstItem="4cY-yy-Wau" firstAttribute="top" secondItem="7zB-OQ-P43" secondAttribute="bottom" id="YHQ-nu-g6m"/>
-                            <constraint firstItem="KrY-U2-tGZ" firstAttribute="top" secondItem="4cY-yy-Wau" secondAttribute="bottom" constant="8" id="eCS-6K-95d"/>
-                            <constraint firstItem="7zB-OQ-P43" firstAttribute="top" secondItem="cbG-vC-cwF" secondAttribute="bottom" id="sf0-4e-LUB"/>
-                            <constraint firstAttribute="trailing" secondItem="4cY-yy-Wau" secondAttribute="trailing" id="wzl-Jw-fpT"/>
+                            <constraint firstItem="0l0-Ib-qwY" firstAttribute="top" secondItem="cbG-vC-cwF" secondAttribute="bottom" id="B6X-eD-jtj"/>
+                            <constraint firstItem="0l0-Ib-qwY" firstAttribute="leading" secondItem="wcv-6k-DXR" secondAttribute="leading" id="KWB-eI-Gkt"/>
+                            <constraint firstAttribute="trailing" secondItem="0l0-Ib-qwY" secondAttribute="trailing" id="ODP-Ga-pYd"/>
+                            <constraint firstItem="KrY-U2-tGZ" firstAttribute="top" secondItem="0l0-Ib-qwY" secondAttribute="bottom" id="gnq-UC-uAA"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="title" id="xWT-K2-Lfp">
@@ -93,7 +94,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2xB-ci-cta" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-342" y="-407"/>
+            <point key="canvasLocation" x="-196" y="-412"/>
         </scene>
     </scenes>
 </document>

--- a/SwiftyPickerPopover/Base.lproj/DatePickerPopover.storyboard
+++ b/SwiftyPickerPopover/Base.lproj/DatePickerPopover.storyboard
@@ -13,6 +13,7 @@
         <scene sceneID="Wzr-YZ-hfN">
             <objects>
                 <navigationController id="byJ-Vv-M5N" sceneMemberID="viewController">
+                    <value key="contentSizeForViewInPopover" type="size" width="300" height="300"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="sFP-QF-Beb">
                         <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/SwiftyPickerPopover/Base.lproj/DatePickerPopover.storyboard
+++ b/SwiftyPickerPopover/Base.lproj/DatePickerPopover.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.17" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="byJ-Vv-M5N">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="byJ-Vv-M5N">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,9 +13,8 @@
         <scene sceneID="Wzr-YZ-hfN">
             <objects>
                 <navigationController id="byJ-Vv-M5N" sceneMemberID="viewController">
-                    <value key="contentSizeForViewInPopover" type="size" width="300" height="300"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="sFP-QF-Beb">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -38,36 +37,36 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="7zB-OQ-P43">
-                                <rect key="frame" x="0.0" y="64" width="414" height="634"/>
-                                <date key="date" timeIntervalSinceReferenceDate="495455736.64444602">
-                                    <!--2016-09-13 10:35:36 +0000-->
-                                </date>
-                                <connections>
-                                    <action selector="pickerValueChanged:" destination="erI-yJ-JEk" eventType="valueChanged" id="U5r-kP-lXN"/>
-                                </connections>
-                            </datePicker>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4cY-yy-Wau">
-                                <rect key="frame" x="0.0" y="698" width="414" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="oSp-Dx-5ub"/>
-                                </constraints>
-                                <state key="normal" title="Clear"/>
-                                <connections>
-                                    <action selector="tappedClear:" destination="erI-yJ-JEk" eventType="touchUpInside" id="cMx-Qs-KEL"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="R5c-bl-QZD">
+                                <rect key="frame" x="0.0" y="64" width="414" height="672"/>
+                                <subviews>
+                                    <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="7zB-OQ-P43">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="642"/>
+                                        <date key="date" timeIntervalSinceReferenceDate="495455736.64444602">
+                                            <!--2016-09-13 10:35:36 +0000-->
+                                        </date>
+                                        <connections>
+                                            <action selector="pickerValueChanged:" destination="erI-yJ-JEk" eventType="valueChanged" id="U5r-kP-lXN"/>
+                                        </connections>
+                                    </datePicker>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4cY-yy-Wau">
+                                        <rect key="frame" x="0.0" y="642" width="414" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="oSp-Dx-5ub"/>
+                                        </constraints>
+                                        <state key="normal" title="Clear"/>
+                                        <connections>
+                                            <action selector="tappedClear:" destination="erI-yJ-JEk" eventType="touchUpInside" id="cMx-Qs-KEL"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="4cY-yy-Wau" secondAttribute="trailing" id="1fv-rE-uSY"/>
-                            <constraint firstItem="4cY-yy-Wau" firstAttribute="leading" secondItem="wcv-6k-DXR" secondAttribute="leading" id="8bc-BX-xCK"/>
-                            <constraint firstAttribute="trailing" secondItem="7zB-OQ-P43" secondAttribute="trailing" id="9RB-ls-UNS"/>
-                            <constraint firstItem="7zB-OQ-P43" firstAttribute="top" secondItem="cbG-vC-cwF" secondAttribute="bottom" id="QxE-V2-F5C"/>
-                            <constraint firstItem="KrY-U2-tGZ" firstAttribute="top" secondItem="4cY-yy-Wau" secondAttribute="bottom" constant="8" id="aOX-zI-LFx"/>
-                            <constraint firstItem="7zB-OQ-P43" firstAttribute="leading" secondItem="wcv-6k-DXR" secondAttribute="leading" id="hae-tz-b0f"/>
-                            <constraint firstAttribute="bottom" secondItem="7zB-OQ-P43" secondAttribute="bottom" priority="250" constant="8" id="iD6-NR-jMv"/>
-                            <constraint firstItem="4cY-yy-Wau" firstAttribute="top" secondItem="7zB-OQ-P43" secondAttribute="bottom" id="yli-tL-4Vv"/>
+                            <constraint firstItem="KrY-U2-tGZ" firstAttribute="top" secondItem="R5c-bl-QZD" secondAttribute="bottom" id="X0f-NI-jfK"/>
+                            <constraint firstAttribute="trailing" secondItem="R5c-bl-QZD" secondAttribute="trailing" id="mBW-0J-TSp"/>
+                            <constraint firstItem="R5c-bl-QZD" firstAttribute="leading" secondItem="wcv-6k-DXR" secondAttribute="leading" id="oa9-rq-nqa"/>
+                            <constraint firstItem="R5c-bl-QZD" firstAttribute="top" secondItem="cbG-vC-cwF" secondAttribute="bottom" id="zrI-i0-gSU"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="title" id="xWT-K2-Lfp">
@@ -83,6 +82,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <value key="contentSizeForViewInPopover" type="size" width="300" height="300"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <connections>
                         <outlet property="cancelButton" destination="vwO-pz-IdI" id="nX9-at-xPI"/>
                         <outlet property="clearButton" destination="4cY-yy-Wau" id="Ohn-Mu-Hs3"/>
@@ -92,7 +92,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2xB-ci-cta" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-342.39999999999998" y="-407.49625187406298"/>
+            <point key="canvasLocation" x="-196" y="-422"/>
         </scene>
     </scenes>
 </document>

--- a/SwiftyPickerPopover/Base.lproj/StringPickerPopover.storyboard
+++ b/SwiftyPickerPopover/Base.lproj/StringPickerPopover.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13168.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Vlu-nf-qJc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Vlu-nf-qJc">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13147.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,9 +15,8 @@
                 <navigationController id="Vlu-nf-qJc" sceneMemberID="viewController">
                     <value key="contentSizeForViewInPopover" type="size" width="300" height="300"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="300" height="300"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="bbG-aM-kwI">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
@@ -38,19 +37,28 @@
                         <viewControllerLayoutGuide type="bottom" id="tOz-Gm-pij"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="cBE-9P-52d">
-                        <rect key="frame" x="0.0" y="0.0" width="300" height="300"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tJe-Py-ArN">
-                                <rect key="frame" x="0.0" y="0.0" width="300" height="300"/>
-                            </pickerView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="oa7-FA-D0J">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <pickerView contentMode="scaleToFill" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="tJe-Py-ArN">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                                    </pickerView>
+                                    <button opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="44" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j9H-Vq-pbw">
+                                        <rect key="frame" x="0.0" y="623" width="375" height="44"/>
+                                        <state key="normal" title="Clear"/>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="tJe-Py-ArN" firstAttribute="leading" secondItem="cBE-9P-52d" secondAttribute="leading" id="98t-4I-CPt"/>
-                            <constraint firstItem="tJe-Py-ArN" firstAttribute="top" secondItem="cBE-9P-52d" secondAttribute="top" id="NNL-y9-LRz"/>
-                            <constraint firstAttribute="trailing" secondItem="tJe-Py-ArN" secondAttribute="trailing" id="Vqd-29-kE5"/>
-                            <constraint firstItem="tOz-Gm-pij" firstAttribute="top" secondItem="tJe-Py-ArN" secondAttribute="bottom" id="pm8-kS-z0e"/>
+                            <constraint firstItem="oa7-FA-D0J" firstAttribute="top" secondItem="cBE-9P-52d" secondAttribute="top" id="9AD-ca-pud"/>
+                            <constraint firstAttribute="trailing" secondItem="oa7-FA-D0J" secondAttribute="trailing" id="Qjj-t5-GDS"/>
+                            <constraint firstItem="tOz-Gm-pij" firstAttribute="top" secondItem="oa7-FA-D0J" secondAttribute="bottom" id="jIk-6c-7OQ"/>
+                            <constraint firstItem="oa7-FA-D0J" firstAttribute="leading" secondItem="cBE-9P-52d" secondAttribute="leading" id="nTL-gR-Ayv"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Title" id="0qf-St-WhE">
@@ -67,9 +75,9 @@
                     </navigationItem>
                     <value key="contentSizeForViewInPopover" type="size" width="300" height="300"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="300" height="300"/>
                     <connections>
                         <outlet property="cancelButton" destination="a1u-Fu-SLI" id="pCt-rp-fSc"/>
+                        <outlet property="clearButton" destination="j9H-Vq-pbw" id="f0O-bH-HqF"/>
                         <outlet property="doneButton" destination="NGv-xi-ME4" id="PQL-FR-PK6"/>
                         <outlet property="picker" destination="tJe-Py-ArN" id="0ed-HW-3nL"/>
                     </connections>

--- a/SwiftyPickerPopover/Base.lproj/StringPickerPopover.storyboard
+++ b/SwiftyPickerPopover/Base.lproj/StringPickerPopover.storyboard
@@ -49,6 +49,9 @@
                                     <button opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="44" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j9H-Vq-pbw">
                                         <rect key="frame" x="0.0" y="623" width="375" height="44"/>
                                         <state key="normal" title="Clear"/>
+                                        <connections>
+                                            <action selector="tappedClear:" destination="pEv-eJ-a7K" eventType="touchUpInside" id="Xkg-Mh-xgO"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                             </stackView>

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.storyboard
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.17" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Vlu-nf-qJc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Vlu-nf-qJc">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,7 +16,7 @@
                     <value key="contentSizeForViewInPopover" type="size" width="300" height="300"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="bbG-aM-kwI">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -39,16 +39,28 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tJe-Py-ArN">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bBN-ZK-3Ap">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                            </pickerView>
+                                <subviews>
+                                    <pickerView contentMode="scaleToFill" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="tJe-Py-ArN">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                                    </pickerView>
+                                    <button opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="375" placeholderIntrinsicHeight="44" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VCx-LB-zU9">
+                                        <rect key="frame" x="0.0" y="623" width="375" height="44"/>
+                                        <state key="normal" title="Clear"/>
+                                        <connections>
+                                            <action selector="tappedClear:" destination="pEv-eJ-a7K" eventType="touchUpInside" id="8Aq-JU-8qG"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="tJe-Py-ArN" firstAttribute="leading" secondItem="cBE-9P-52d" secondAttribute="leading" id="9du-3u-ELh"/>
-                            <constraint firstItem="tJe-Py-ArN" firstAttribute="top" secondItem="cBE-9P-52d" secondAttribute="top" id="lsN-Wt-Nxt"/>
-                            <constraint firstItem="tOz-Gm-pij" firstAttribute="top" secondItem="tJe-Py-ArN" secondAttribute="bottom" id="nhk-Tw-uYu"/>
-                            <constraint firstAttribute="trailing" secondItem="tJe-Py-ArN" secondAttribute="trailing" id="pR2-bS-Fm5"/>
+                            <constraint firstItem="bBN-ZK-3Ap" firstAttribute="top" secondItem="cBE-9P-52d" secondAttribute="top" id="1jT-5j-g09"/>
+                            <constraint firstAttribute="trailing" secondItem="bBN-ZK-3Ap" secondAttribute="trailing" id="Jve-Wb-ug1"/>
+                            <constraint firstItem="bBN-ZK-3Ap" firstAttribute="leading" secondItem="cBE-9P-52d" secondAttribute="leading" id="Ph3-of-IJ7"/>
+                            <constraint firstItem="tOz-Gm-pij" firstAttribute="top" secondItem="bBN-ZK-3Ap" secondAttribute="bottom" id="Qzf-rz-oV6"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Title" id="0qf-St-WhE">
@@ -67,6 +79,7 @@
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <connections>
                         <outlet property="cancelButton" destination="a1u-Fu-SLI" id="3Zc-w0-zd8"/>
+                        <outlet property="clearButton" destination="VCx-LB-zU9" id="Kbn-4c-ds4"/>
                         <outlet property="doneButton" destination="NGv-xi-ME4" id="1p3-fa-ieC"/>
                         <outlet property="picker" destination="tJe-Py-ArN" id="0ed-HW-3nL"/>
                     </connections>

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -22,7 +22,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// Popover type
     public typealias PopoverType = ColumnStringPickerPopover
     /// Action type for buttons
-    public typealias ActionHandlerType = (PopoverType, [Int], [ItemType])->Void
+    public typealias ActionHandlerType = (PopoverType, [Int], [ItemType]) -> Void
     /// Button parameters type
     public typealias ButtonParameterType = (title: String, font: UIFont?, color: UIColor?, action: ActionHandlerType?)
     /// Type of the rule closure to convert from a raw value to the display string
@@ -195,7 +195,6 @@ extension ColumnStringPickerPopover: UIPickerViewDelegate{
         valueChangeAction?(self, selectedRows, selectedValues())
         redoDisappearAutomatically()
     }
-
 }
 
 // MARK: - UIPickerViewDataSource
@@ -236,5 +235,4 @@ extension ColumnStringPickerPopover: UIPickerViewDataSource{
         }
         return result
     }
- 
 }

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -50,6 +50,7 @@ public class ColumnStringPickerPopover: AbstractPopover {
     private(set) var doneButton: ButtonParameterType = (title: "Done".localized, font: nil, color: nil, action: nil)
     /// Cancel button parameters
     private(set) var cancelButton: ButtonParameterType = (title: "Cancel".localized, font: nil, color: nil, action: nil)
+    private(set) var clearButton: ButtonParameterType = (title: "Clear".localized, font: nil, color: nil, action: nil)
 
     /// Action for picker value change
     private(set) var valueChangeAction: ActionHandlerType?
@@ -117,6 +118,22 @@ public class ColumnStringPickerPopover: AbstractPopover {
         return setButton(button: &cancelButton, title:title, font: font, color: color, action: action)
     }
 
+    /// - Parameters:
+    ///   - title: Title for the button. Omissible.
+    ///   - font: Button title font. Omissible.
+    ///   - color: Button tint color. Omissible. If this is nil or not specified, then the button tintColor inherits appear()'s baseViewController.view.tintColor.
+    ///   - completion: Action to be performed before the popover disappeared.
+    /// - Returns: Self
+    public func setClearButton(title: String? = nil, font: UIFont? = nil, color: UIColor? = nil, action: ActionHandlerType?) -> Self {
+        let kHomeValue = ""
+        for componet in 0..<choices.count {
+            if let firstItem = choices[componet].first, firstItem != kHomeValue {
+                choices[componet].insert(kHomeValue, at: 0)
+            }
+        }
+        return setButton(button: &clearButton, title:title, font: font, color: color, action: action)
+    }
+    
     /// Set button arguments to the targeted button propertoes
     ///
     /// - Parameters:

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -33,18 +33,18 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// Choice array. Nest.
     private(set) var choices: [[ItemType]] = [[]]
     /// Selected rows
-    private(set) var selectedRows: [Int] = [Int]()
+    var selectedRows: [Int] = [Int]()
     /// Column ratio
     private(set) var columnPercents: [Float] = [Float]()
     ///Font
     private(set) var fonts: [UIFont?]?
     private(set) var fontSizes: [CGFloat?]?
-    private let kDefaultFontSize:CGFloat = 12
+    let kDefaultFontSize: CGFloat = 12
     private(set) var fontColors: [UIColor?]?
-    private let kDefaultFontColor: UIColor = .black
+    let kDefaultFontColor: UIColor = .black
 
     /// Convert a raw value to the string for displaying it
-    private var displayStringFor: DisplayStringForType?
+    private(set) var displayStringFor: DisplayStringForType?
     
     /// Done button parameters
     private(set) var doneButton: ButtonParameterType = (title: "Done".localized, font: nil, color: nil, action: nil)
@@ -166,73 +166,5 @@ public class ColumnStringPickerPopover: AbstractPopover {
     public func setFontSizes(_ fontSizes:[CGFloat?])->Self{
         self.fontSizes = fontSizes
         return self
-    }
-}
-
-// MARK: - UIPickerViewDelegate
-extension ColumnStringPickerPopover: UIPickerViewDelegate{
-    public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        let label:UILabel = view as? UILabel ?? UILabel()
-        
-        let title = choices[component][row]
-        label.text = choice(component: component, row: row)
-        
-        let fontSize: CGFloat = fontSizes?[component] ?? kDefaultFontSize
-        let font: UIFont = fonts?[component] ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular)
-        let fontColor: UIColor = fontColors?[component] ?? kDefaultFontColor
-        let attributedTitle = NSAttributedString(string: title, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: fontColor])
-        label.attributedText = attributedTitle
-        
-        label.textAlignment = .center
-        return label
-    }
-    
-    public func pickerView(_ pickerView: UIPickerView,
-                           didSelectRow row: Int,
-                           inComponent component: Int){
-        
-        selectedRows[component] = row
-        valueChangeAction?(self, selectedRows, selectedValues())
-        redoDisappearAutomatically()
-    }
-}
-
-// MARK: - UIPickerViewDataSource
-extension ColumnStringPickerPopover: UIPickerViewDataSource{
-    
-    /// UIPickerViewDataSource
-    public func numberOfComponents(in pickerView: UIPickerView) -> Int {
-        return choices.count
-    }
-    
-    public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return choices[component].count
-    }
-    
-    public func pickerView(_ pickerView: UIPickerView,
-                           widthForComponent component: Int) -> CGFloat {
-        let width = Float(pickerView.frame.size.width)
-        let temp = width * columnPercents[component]
-        return CGFloat(temp)
-    }
-    
-    // get string of choice
-    func choice(component: Int, row: Int)->ItemType? {
-        guard let items = choices[safe: component],
-            let selectedValue = items[safe: row] else {
-                return nil
-        }
-       return displayStringFor?(selectedValue) ?? selectedValue
-    }
-    
-    // get array of selected values
-    func selectedValues()->[ItemType]{
-        var result = [ItemType]()
-        for (index, content) in selectedRows.enumerated() {
-            if let string = choice(component: index, row: content){
-                result.append(string)
-            }
-        }
-        return result
     }
 }

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.swift
@@ -28,6 +28,9 @@ public class ColumnStringPickerPopover: AbstractPopover {
     /// Type of the rule closure to convert from a raw value to the display string
     public typealias DisplayStringForType = ((ItemType?)->String?)
 
+    // MARK: Constants
+    let kValueForCleared: ItemType = ""
+    
     // MARK: - Properties
 
     /// Choice array. Nest.
@@ -125,10 +128,10 @@ public class ColumnStringPickerPopover: AbstractPopover {
     ///   - completion: Action to be performed before the popover disappeared.
     /// - Returns: Self
     public func setClearButton(title: String? = nil, font: UIFont? = nil, color: UIColor? = nil, action: ActionHandlerType?) -> Self {
-        let kHomeValue = ""
+        // Insert the value like "" if needed
         for componet in 0..<choices.count {
-            if let firstItem = choices[componet].first, firstItem != kHomeValue {
-                choices[componet].insert(kHomeValue, at: 0)
+            if let firstItem = choices[componet].first, firstItem != kValueForCleared {
+                choices[componet].insert(kValueForCleared, at: 0)
             }
         }
         return setButton(button: &clearButton, title:title, font: font, color: color, action: action)

--- a/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
@@ -95,7 +95,7 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
         guard !clearButton.isHidden else {
             return
         }
-        clearButton.isEnabled = selectedValues().filter({ $0 != ""}).count > 0
+        clearButton.isEnabled = selectedValues().filter({ $0 != popover.kValueForCleared}).count > 0
     }
     
     private func tapped(button: ColumnStringPickerPopover.ButtonParameterType?) {

--- a/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
@@ -21,7 +21,7 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
     // MARK: Properties
     
     /// Popover
-    private var popover: PopoverType? { return anyPopover as? PopoverType }
+    private var popover: PopoverType! { return anyPopover as? PopoverType }
 
     @IBOutlet weak private var cancelButton: UIBarButtonItem!
     @IBOutlet weak private var doneButton: UIBarButtonItem!
@@ -43,16 +43,16 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
             navigationItem.rightBarButtonItem = nil
         }
         
-        cancelButton.title = popover?.cancelButton.title
-        cancelButton.tintColor = popover?.cancelButton.color ?? popover?.tintColor
+        cancelButton.title = popover.cancelButton.title
+        cancelButton.tintColor = popover.cancelButton.color ?? popover.tintColor
         navigationItem.setLeftBarButton(cancelButton, animated: false)
 
-        doneButton.title = popover?.doneButton.title
-        doneButton.tintColor = popover?.doneButton.color ?? popover?.tintColor
+        doneButton.title = popover.doneButton.title
+        doneButton.tintColor = popover.doneButton.color ?? popover.tintColor
         navigationItem.setRightBarButton(doneButton, animated: false)
 
         // Select row if needed
-        popover?.selectedRows.enumerated().forEach {
+        popover.selectedRows.enumerated().forEach {
             picker.selectRow($0.1, inComponent: $0.0, animated: true)
         }
     }
@@ -61,18 +61,17 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
     ///
     /// - Parameter sender: Done button
     @IBAction func tappedDone(_ sender: AnyObject? = nil) {
-        tapped(button: popover?.doneButton)
+        tapped(button: popover.doneButton)
     }
     
     /// Action when tapping cancel button
     ///
     /// - Parameter sender: Cancel button
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
-        tapped(button: popover?.cancelButton)
+        tapped(button: popover.cancelButton)
     }
     
     private func tapped(button: ColumnStringPickerPopover.ButtonParameterType?) {
-        guard let popover = popover else { return }
         let selectedRows = popover.selectedRows
         let selectedChoices = popover.selectedValues()
         button?.action?(popover, selectedRows, selectedChoices)

--- a/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
@@ -81,10 +81,17 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
         tapped(button: popover.cancelButton)
     }
     
+    private func tapped(button: ColumnStringPickerPopover.ButtonParameterType?) {
+        let selectedRows = popover.selectedRows
+        let selectedChoices = selectedValues()
+        button?.action?(popover, selectedRows, selectedChoices)
+        dismiss(animated: false, completion: {})
+    }
+    
     @IBAction func tappedClear(_ sender: AnyObject? = nil) {
-        let kHomeRow = 0
+        // Select row 0 in each componet
         for componet in 0..<picker.numberOfComponents {
-            picker.selectRow(kHomeRow, inComponent: componet, animated: true)
+            picker.selectRow(0, inComponent: componet, animated: true)
         }
         enableClearButtonIfNeeded()
         popover.clearButton.action?(popover, popover.selectedRows, selectedValues())
@@ -96,13 +103,6 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
             return
         }
         clearButton.isEnabled = selectedValues().filter({ $0 != popover.kValueForCleared}).count > 0
-    }
-    
-    private func tapped(button: ColumnStringPickerPopover.ButtonParameterType?) {
-        let selectedRows = popover.selectedRows
-        let selectedChoices = selectedValues()
-        button?.action?(popover, selectedRows, selectedChoices)
-        dismiss(animated: false, completion: {})
     }
     
     /// Action to be executed after the popover disappears

--- a/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
@@ -85,7 +85,7 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
         let selectedRows = popover.selectedRows
         let selectedChoices = selectedValues()
         button?.action?(popover, selectedRows, selectedChoices)
-        dismiss(animated: false, completion: {})
+        dismiss(animated: false)
     }
     
     @IBAction func tappedClear(_ sender: AnyObject? = nil) {
@@ -128,8 +128,7 @@ extension ColumnStringPickerPopoverViewController: UIPickerViewDataSource {
         return pickerView.frame.size.width * CGFloat(popover.columnPercents[component])
     }
     
-    // get string of choice
-    func choice(component: Int, row: Int) -> ColumnStringPickerPopover.ItemType? {
+    private func selectedValue(component: Int, row: Int) -> ColumnStringPickerPopover.ItemType? {
         guard let items = popover.choices[safe: component],
             let selectedValue = items[safe: row] else {
                 return nil
@@ -137,12 +136,11 @@ extension ColumnStringPickerPopoverViewController: UIPickerViewDataSource {
         return popover.displayStringFor?(selectedValue) ?? selectedValue
     }
     
-    // get array of selected values
-    func selectedValues() -> [ColumnStringPickerPopover.ItemType] {
+    private func selectedValues() -> [ColumnStringPickerPopover.ItemType] {
         var result = [ColumnStringPickerPopover.ItemType]()
-        for (index, content) in popover.selectedRows.enumerated() {
-            if let string = choice(component: index, row: content){
-                result.append(string)
+        popover.selectedRows.enumerated().forEach {
+            if let value = selectedValue(component: $0.offset, row: $0.element){
+                result.append(value)
             }
         }
         return result
@@ -152,7 +150,7 @@ extension ColumnStringPickerPopoverViewController: UIPickerViewDataSource {
 extension ColumnStringPickerPopoverViewController: UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
         let label: UILabel = view as? UILabel ?? UILabel()
-        label.text = choice(component: component, row: row)
+        label.text = selectedValue(component: component, row: row)
 
         let fontSize: CGFloat = popover.fontSizes?[component] ?? popover.kDefaultFontSize
         let font: UIFont = popover.fonts?[component] ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular)

--- a/SwiftyPickerPopover/CountdownPickerPopover.swift
+++ b/SwiftyPickerPopover/CountdownPickerPopover.swift
@@ -13,7 +13,7 @@ public class CountdownPickerPopover: AbstractPopover {
     /// Popover type
     public typealias PopoverType = CountdownPickerPopover
     /// Action type for buttons
-    public typealias ActionHandlerType = (PopoverType, ItemType)->Void
+    public typealias ActionHandlerType = (PopoverType, ItemType) -> Void
     /// Button parameters type
     public typealias ButtonParameterType = (title: String, font: UIFont?, color: UIColor?, action: ActionHandlerType?)
 
@@ -114,7 +114,7 @@ public class CountdownPickerPopover: AbstractPopover {
     /// - Parameters:
     ///   -action: Action to be performed each time the picker is moved to a new value.
     /// - Returns: Self
-    public func setValueChange(action: ActionHandlerType?)->Self{
+    public func setValueChange(action: ActionHandlerType?) -> Self{
         valueChangeAction = action
         return self
     }

--- a/SwiftyPickerPopover/CountdownPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/CountdownPickerPopoverViewController.swift
@@ -56,12 +56,12 @@ public class CountdownPickerPopoverViewController: AbstractPickerPopoverViewCont
     
     @IBAction func tappedDone(_ sender: UIButton? = nil) {
         popover.doneButton.action?(popover, picker.countDownDuration)
-        dismiss(animated: false, completion: {})
+        dismiss(animated: false)
     }
     
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
         popover.cancelButton.action?(popover, picker.countDownDuration)
-        dismiss(animated: false, completion: {})
+        dismiss(animated: false)
     }
     
     @IBAction func tappedClear(_ sender: UIButton? = nil) {

--- a/SwiftyPickerPopover/CountdownPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/CountdownPickerPopoverViewController.swift
@@ -15,7 +15,7 @@ public class CountdownPickerPopoverViewController: AbstractPickerPopoverViewCont
     
     typealias PopoverType = CountdownPickerPopover
 
-    private var popover: PopoverType? { return anyPopover as? PopoverType }
+    private var popover: PopoverType! { return anyPopover as? PopoverType }
 
     @IBOutlet weak private var doneButton: UIBarButtonItem!
     @IBOutlet weak private var cancelButton: UIBarButtonItem!
@@ -24,9 +24,6 @@ public class CountdownPickerPopoverViewController: AbstractPickerPopoverViewCont
     
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
-        guard let popover = popover else {
-            return
-        }
         if #available(iOS 11.0, *) { }
         else {
             navigationItem.leftBarButtonItem = nil
@@ -58,28 +55,26 @@ public class CountdownPickerPopoverViewController: AbstractPickerPopoverViewCont
     }
     
     @IBAction func tappedDone(_ sender: UIButton? = nil) {
-        popover?.doneButton.action?(popover!, picker.countDownDuration)
+        popover.doneButton.action?(popover, picker.countDownDuration)
         dismiss(animated: false, completion: {})
     }
     
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
-        popover?.cancelButton.action?(popover!, picker.countDownDuration)
+        popover.cancelButton.action?(popover, picker.countDownDuration)
         dismiss(animated: false, completion: {})
     }
     
     @IBAction func tappedClear(_ sender: UIButton? = nil) {
-        popover?.redoDisappearAutomatically()
-        popover?.clearButton.action?(popover!, picker.countDownDuration)
+        popover.redoDisappearAutomatically()
+        popover.clearButton.action?(popover, picker.countDownDuration)
     }
     
-    
     @IBAction func pickerValueChanged(_ sender: UIDatePicker) {
-        popover?.valueChangeAction?(popover!, picker.countDownDuration)
-        popover?.redoDisappearAutomatically()
+        popover.valueChangeAction?(popover, picker.countDownDuration)
+        popover.redoDisappearAutomatically()
     }
     
     func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
         tappedCancel()
     }
-
 }

--- a/SwiftyPickerPopover/CountdownPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/CountdownPickerPopoverViewController.swift
@@ -24,37 +24,34 @@ public class CountdownPickerPopoverViewController: AbstractPickerPopoverViewCont
     
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
-
+        guard let popover = popover else {
+            return
+        }
         if #available(iOS 11.0, *) { }
         else {
             navigationItem.leftBarButtonItem = nil
             navigationItem.rightBarButtonItem = nil
         }
-        cancelButton.title = popover?.cancelButton.title
-        if let font = popover?.cancelButton.font {
+        cancelButton.title = popover.cancelButton.title
+        if let font = popover.cancelButton.font {
             cancelButton.setTitleTextAttributes([NSAttributedStringKey.font: font], for: .normal)
         }
-        cancelButton.tintColor = popover?.cancelButton.color ?? popover?.tintColor
+        cancelButton.tintColor = popover.cancelButton.color ?? popover.tintColor
         navigationItem.setLeftBarButton(cancelButton, animated: false)
         
-        doneButton.title = popover?.doneButton.title
-        if let font = popover?.doneButton.font {
+        doneButton.title = popover.doneButton.title
+        if let font = popover.doneButton.font {
             doneButton.setTitleTextAttributes([NSAttributedStringKey.font: font], for: .normal)
         }
-        doneButton.tintColor = popover?.doneButton.color ?? popover?.tintColor
+        doneButton.tintColor = popover.doneButton.color ?? popover.tintColor
         navigationItem.setRightBarButton(doneButton, animated: false)
 
-        clearButton.setTitle(popover?.clearButton.title, for: .normal)
-        if let font = popover?.clearButton.font {
+        clearButton.setTitle(popover.clearButton.title, for: .normal)
+        if let font = popover.clearButton.font {
             clearButton.titleLabel?.font = font
         }
-        clearButton.tintColor = popover?.clearButton.color ?? popover?.tintColor
-        
-        guard let popover = popover else { return }
-        if popover.clearButton.action == nil {
-            clearButton.removeFromSuperview()
-            view.layoutIfNeeded()
-        }
+        clearButton.tintColor = popover.clearButton.color ?? popover.tintColor
+        clearButton.isHidden = popover.clearButton.action == nil
 
         picker.datePickerMode = .countDownTimer
         picker.countDownDuration = popover.selectedTimeInterval

--- a/SwiftyPickerPopover/DatePickerPopover.swift
+++ b/SwiftyPickerPopover/DatePickerPopover.swift
@@ -15,7 +15,7 @@ public class DatePickerPopover: AbstractPopover {
     /// Popover type
     public typealias PopoverType = DatePickerPopover
     /// Action type for buttons
-    public typealias ActionHandlerType = (PopoverType, ItemType)->Void
+    public typealias ActionHandlerType = (PopoverType, ItemType) -> Void
     /// Button parameters type
     public typealias ButtonParameterType = (title: String, font: UIFont?, color: UIColor?, action: ActionHandlerType?)
 
@@ -183,14 +183,5 @@ public class DatePickerPopover: AbstractPopover {
     public func setValueChange(action: ActionHandlerType?)->Self{
         valueChangeAction = action
         return self
-    }
-    
-    // MARK: - Popover display
-    
-    public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        //Redo disapperAutomatically()
-        if let seconds = disappearAutomaticallyItems.seconds {
-            disappearAutomatically(after: seconds, completion: disappearAutomaticallyItems.completion)
-        }
-    }
+    }    
 }

--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -19,38 +19,36 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
     
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
-        
+        guard let popover = popover else {
+            return
+        }
         if #available(iOS 11.0, *) { }
         else {
             navigationItem.leftBarButtonItem = nil
             navigationItem.rightBarButtonItem = nil
         }
-        cancelButton.title = popover?.cancelButton.title
-        if let font = popover?.cancelButton.font {
+        cancelButton.title = popover.cancelButton.title
+        if let font = popover.cancelButton.font {
             cancelButton.setTitleTextAttributes([NSAttributedStringKey.font: font], for: .normal)
         }
-        cancelButton.tintColor = popover?.cancelButton.color ?? popover?.tintColor
+        cancelButton.tintColor = popover.cancelButton.color ?? popover.tintColor
         navigationItem.setLeftBarButton(cancelButton, animated: false)
         
-        doneButton.title = popover?.doneButton.title
-        if let font = popover?.doneButton.font {
+        doneButton.title = popover.doneButton.title
+        if let font = popover.doneButton.font {
             doneButton.setTitleTextAttributes([NSAttributedStringKey.font: font], for: .normal)
         }
-        doneButton.tintColor = popover?.doneButton.color ?? popover?.tintColor
+        doneButton.tintColor = popover.doneButton.color ?? popover.tintColor
         navigationItem.setRightBarButton(doneButton, animated: false)
         
-        clearButton.setTitle(popover?.clearButton.title, for: .normal)
-        if let font = popover?.clearButton.font {
+        clearButton.setTitle(popover.clearButton.title, for: .normal)
+        if let font = popover.clearButton.font {
             clearButton.titleLabel?.font = font
         }
-        clearButton.tintColor = popover?.clearButton.color ?? popover?.tintColor
+        clearButton.tintColor = popover.clearButton.color ?? popover.tintColor
 
-        if popover?.clearButton.action == nil {
-            clearButton.removeFromSuperview()
-            view.layoutIfNeeded()
-        }
+        clearButton.isHidden = popover.clearButton.action == nil
 
-        guard let popover = popover else { return }
         picker.date = popover.selectedDate
         picker.minimumDate = popover.minimumDate
         picker.maximumDate = popover.maximumDate

--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -70,7 +70,7 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
     
     private func tapped(button: DatePickerPopover.ButtonParameterType?) {
         button?.action?(popover, picker.date)
-        dismiss(animated: false, completion: {})
+        dismiss(animated: false)
     }
     
     @IBAction func pickerValueChanged(_ sender: UIDatePicker) {

--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -10,7 +10,7 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
     
     typealias PopoverType = DatePickerPopover
     
-    private var popover: PopoverType! { return anyPopover as? PopoverType }
+    fileprivate var popover: PopoverType! { return anyPopover as? PopoverType }
     
     @IBOutlet weak private var picker: UIDatePicker!
     @IBOutlet weak private var cancelButton: UIBarButtonItem!

--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -10,7 +10,7 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
     
     typealias PopoverType = DatePickerPopover
     
-    private var popover: PopoverType? { return anyPopover as? PopoverType }
+    private var popover: PopoverType! { return anyPopover as? PopoverType }
     
     @IBOutlet weak private var picker: UIDatePicker!
     @IBOutlet weak private var cancelButton: UIBarButtonItem!
@@ -19,9 +19,6 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
     
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
-        guard let popover = popover else {
-            return
-        }
         if #available(iOS 11.0, *) { }
         else {
             navigationItem.leftBarButtonItem = nil
@@ -46,7 +43,6 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
             clearButton.titleLabel?.font = font
         }
         clearButton.tintColor = popover.clearButton.color ?? popover.tintColor
-
         clearButton.isHidden = popover.clearButton.action == nil
 
         picker.date = popover.selectedDate
@@ -60,26 +56,26 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
     }
 
     @IBAction func tappedDone(_ sender: UIButton? = nil) {
-        tapped(button: popover?.doneButton)
+        tapped(button: popover.doneButton)
     }
     
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
-        tapped(button: popover?.cancelButton)
+        tapped(button: popover.cancelButton)
     }
     
     @IBAction func tappedClear(_ sender: UIButton? = nil) {
-        popover?.clearButton.action?(popover!, picker.date)
-        popover?.redoDisappearAutomatically()
+        popover.clearButton.action?(popover, picker.date)
+        popover.redoDisappearAutomatically()
     }
     
     private func tapped(button: DatePickerPopover.ButtonParameterType?) {
-        button?.action?(popover!, picker.date)
+        button?.action?(popover, picker.date)
         dismiss(animated: false, completion: {})
     }
     
     @IBAction func pickerValueChanged(_ sender: UIDatePicker) {
-        popover?.valueChangeAction?(popover!, picker.date)
-        popover?.redoDisappearAutomatically()
+        popover.valueChangeAction?(popover, picker.date)
+        popover.redoDisappearAutomatically()
     }
     
     func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {

--- a/SwiftyPickerPopover/Info.plist
+++ b/SwiftyPickerPopover/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.2.0</string>
+	<string>6.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SwiftyPickerPopover/Info.plist
+++ b/SwiftyPickerPopover/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.0</string>
+	<string>6.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -174,6 +174,9 @@ public class StringPickerPopover: AbstractPopover {
     ///   - completion: Action to be performed before the popover disappeared.
     /// - Returns: Self
     public func setClearButton(title: String? = nil, font: UIFont? = nil, color: UIColor? = nil, action: ActionHandlerType?) -> Self {
+        if let item = choices.first, item != "" {
+            choices.insert("", at: 0)
+        }
         return setButton(button: &clearButton, title:title, font: font, color: color, action: action)
     }
 
@@ -209,55 +212,5 @@ public class StringPickerPopover: AbstractPopover {
     public func setValueChange(action: ActionHandlerType?)->Self{
         valueChangeAction = action
         return self
-    }
-
-}
-
-// MARK: - UIPickerViewDataSource
-extension StringPickerPopover: UIPickerViewDataSource {
-    public func numberOfComponents(in pickerView: UIPickerView) -> Int {
-        return 1
-    }
-    
-    public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return choices.count
-    }
-}
-
-// MARK: - UIPickerViewDelegate
-extension StringPickerPopover: UIPickerViewDelegate {
-    public func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return displayStringFor?(choices[row]) ?? choices[row]
-    }
-    
-    public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
-        let attributedResult = NSMutableAttributedString()
-        
-        if let images = images, let image = images[row] {
-            let imageAttachment = NSTextAttachment()
-            imageAttachment.image = image
-            let attributedImage = NSAttributedString(attachment: imageAttachment)
-            attributedResult.append(attributedImage)
-            
-            let AttributedMargin = NSAttributedString(string: " ")
-            attributedResult.append(AttributedMargin)
-        }
-        
-        let title: String = displayStringFor?(choices[row]) ?? choices[row]
-        let font: UIFont = self.font ?? UIFont.systemFont(ofSize: fontSize, weight: UIFont.Weight.regular)
-        let attributedTitle = NSAttributedString(string: title, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: fontColor])
-
-        attributedResult.append(attributedTitle)
-        return attributedResult
-    }
-    
-    public func pickerView(_ pickerView: UIPickerView,
-                           rowHeightForComponent component: Int) -> CGFloat {
-        return rowHeight
-    }
-    
-    public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        valueChangeAction?(self, row, choices[row])
-        redoDisappearAutomatically()
     }
 }

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -22,6 +22,9 @@ public class StringPickerPopover: AbstractPopover {
     /// Type of the rule closure to convert from a raw value to the display string
     public typealias DisplayStringForType = ((ItemType?)->String?)
 
+    // MARK: Constants
+    let kValueForCleared: ItemType = ""
+
     // MARK: - Properties
     
     /// Choice array
@@ -174,12 +177,12 @@ public class StringPickerPopover: AbstractPopover {
     ///   - completion: Action to be performed before the popover disappeared.
     /// - Returns: Self
     public func setClearButton(title: String? = nil, font: UIFont? = nil, color: UIColor? = nil, action: ActionHandlerType?) -> Self {
-        if let item = choices.first, item != "" {
-            choices.insert("", at: 0)
+        // Insert the value like "" if needed
+        if let item = choices.first, item != kValueForCleared {
+            choices.insert(kValueForCleared, at: 0)
         }
         return setButton(button: &clearButton, title:title, font: font, color: color, action: action)
     }
-
     
     /// Set button arguments to the targeted button properties
     ///

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -41,7 +41,9 @@ public class StringPickerPopover: AbstractPopover {
     private(set) var doneButton: ButtonParameterType = ("Done".localized, nil, nil, nil)
     /// Cancel button parameters
     private(set) var cancelButton: ButtonParameterType = ("Cancel".localized, nil, nil, nil)
-    
+    /// Clear button parameters
+    private(set) var clearButton: ButtonParameterType = ("Clear".localized, nil, nil, nil)
+
     /// Action for picker value change
     private(set) var valueChangeAction: ActionHandlerType?
     
@@ -164,6 +166,17 @@ public class StringPickerPopover: AbstractPopover {
     public func setCancelButton(title:String? = nil, font: UIFont? = nil, color:UIColor? = nil, action:ActionHandlerType?)->Self{
         return setButton(button: &cancelButton, title: title, font: font, color: color, action: action)
     }
+    
+    /// - Parameters:
+    ///   - title: Title for the button. Omissible.
+    ///   - font: Button title font. Omissible.
+    ///   - color: Button tint color. Omissible. If this is nil or not specified, then the button tintColor inherits appear()'s baseViewController.view.tintColor.
+    ///   - completion: Action to be performed before the popover disappeared.
+    /// - Returns: Self
+    public func setClearButton(title: String? = nil, font: UIFont? = nil, color: UIColor? = nil, action: ActionHandlerType?) -> Self {
+        return setButton(button: &clearButton, title:title, font: font, color: color, action: action)
+    }
+
     
     /// Set button arguments to the targeted button properties
     ///

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -16,7 +16,7 @@ public class StringPickerPopover: AbstractPopover {
     /// Popover type
     public typealias PopoverType = StringPickerPopover
     /// Action type for buttons
-    public typealias ActionHandlerType = (PopoverType, Int, ItemType)->Void
+    public typealias ActionHandlerType = (PopoverType, Int, ItemType) -> Void
     /// Button parameters type
     public typealias ButtonParameterType = (title: String, font: UIFont?, color: UIColor?, action: ActionHandlerType?)
     /// Type of the rule closure to convert from a raw value to the display string

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -20,6 +20,7 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     
     @IBOutlet weak private var cancelButton: UIBarButtonItem!
     @IBOutlet weak private var doneButton: UIBarButtonItem!
+    @IBOutlet weak private var clearButton: UIButton!    
     @IBOutlet weak private var picker: UIPickerView!
     
     override public func viewDidLoad() {

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -89,6 +89,14 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
         tapped(button: popover.cancelButton)
     }
     
+    private func tapped(button: StringPickerPopover.ButtonParameterType?) {
+        let selectedRow = picker.selectedRow(inComponent: 0)
+        if let selectedValue = popover.choices[safe: selectedRow] {
+            button?.action?(popover, selectedRow, selectedValue)
+        }
+        dismiss(animated: false, completion: {})
+    }
+
     /// Action when tapping clear button
     ///
     /// - Parameter sender: Clear button
@@ -96,18 +104,10 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
         let kTargetRow = 0
         picker.selectRow(kTargetRow, inComponent: 0, animated: true)
         enableClearButtonIfNeeded()
-        if let selectedString = popover.choices[safe: kTargetRow] {
-            popover.clearButton.action?(popover, kTargetRow, selectedString)
+        if let selectedValue = popover.choices[safe: kTargetRow] {
+            popover.clearButton.action?(popover, kTargetRow, selectedValue)
         }
         popover.redoDisappearAutomatically()
-    }
-    
-    private func tapped(button: StringPickerPopover.ButtonParameterType?) {
-        let selectedRow = picker.selectedRow(inComponent: 0)
-        if let selectedString = popover.choices[safe: selectedRow] {
-            button?.action?(popover, selectedRow, selectedString)
-        }
-        dismiss(animated: false, completion: {})
     }
     
     /// Action to be executed after the popover disappears

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -94,7 +94,7 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
         if let selectedValue = popover.choices[safe: selectedRow] {
             button?.action?(popover, selectedRow, selectedValue)
         }
-        dismiss(animated: false, completion: {})
+        dismiss(animated: false)
     }
 
     /// Action when tapping clear button

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -134,13 +134,14 @@ extension StringPickerPopoverViewController: UIPickerViewDataSource {
 // MARK: - UIPickerViewDelegate
 extension StringPickerPopoverViewController: UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return popover.displayStringFor?(popover.choices[row]) ?? popover.choices[row]
+        let value: String = popover.choices[row]
+        return popover.displayStringFor?(value) ?? value
     }
     
     public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
         let attributedResult = NSMutableAttributedString()
         
-        if let images = popover.images, let image = images[row] {
+        if let image = popover.images?[row] {
             let imageAttachment = NSTextAttachment()
             imageAttachment.image = image
             let attributedImage = NSAttributedString(attachment: imageAttachment)
@@ -150,9 +151,10 @@ extension StringPickerPopoverViewController: UIPickerViewDelegate {
             attributedResult.append(AttributedMargin)
         }
         
-        let title: String = popover.displayStringFor?(popover.choices[row]) ?? popover.choices[row]
+        let value: String = popover.choices[row]
+        let title: String = popover.displayStringFor?(value) ?? value
         let font: UIFont = popover.font ?? UIFont.systemFont(ofSize: popover.fontSize, weight: UIFont.Weight.regular)
-        let attributedTitle = NSAttributedString(string: title, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: popover.fontColor])
+        let attributedTitle: NSAttributedString = NSAttributedString(string: title, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: popover.fontColor])
         
         attributedResult.append(attributedTitle)
         return attributedResult

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -69,8 +69,9 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
             return
         }
         clearButton.isEnabled = false
-        if let selectedRow = picker?.selectedRow(inComponent: 0), let popover = popover, let selectedValue = popover.choices[safe: selectedRow] {
-            clearButton.isEnabled = selectedValue != ""
+        if let selectedRow = picker?.selectedRow(inComponent: 0),
+            let selectedValue = popover.choices[safe: selectedRow] {
+            clearButton.isEnabled = selectedValue != popover.kValueForCleared
         }
     }
     

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -20,9 +20,9 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     
     @IBOutlet weak private var cancelButton: UIBarButtonItem!
     @IBOutlet weak private var doneButton: UIBarButtonItem!
-    @IBOutlet weak private var clearButton: UIButton!    
     @IBOutlet weak private var picker: UIPickerView!
-    
+    @IBOutlet weak private var clearButton: UIButton!
+
     override public func viewDidLoad() {
         super.viewDidLoad()
         picker.delegate = popover
@@ -31,31 +31,40 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     /// Make the popover properties reflect on this view controller
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
-        
+        guard let popover = popover else {
+            return
+        }
+
         // Set up cancel button
         if #available(iOS 11.0, *) { }
         else {
             navigationItem.leftBarButtonItem = nil
             navigationItem.rightBarButtonItem = nil
         }
-        cancelButton.title = popover?.cancelButton.title
-        if let font = popover?.cancelButton.font {
+        cancelButton.title = popover.cancelButton.title
+        if let font = popover.cancelButton.font {
             cancelButton.setTitleTextAttributes([NSAttributedStringKey.font: font], for: .normal)
         }
-        cancelButton.tintColor = popover?.cancelButton.color ?? popover?.tintColor
+        cancelButton.tintColor = popover.cancelButton.color ?? popover.tintColor
         navigationItem.setLeftBarButton(cancelButton, animated: false)
         
-        doneButton.title = popover?.doneButton.title
-        if let font = popover?.doneButton.font {
+        doneButton.title = popover.doneButton.title
+        if let font = popover.doneButton.font {
             doneButton.setTitleTextAttributes([NSAttributedStringKey.font: font], for: .normal)
         }
-        doneButton.tintColor = popover?.doneButton.color ?? popover?.tintColor
+        doneButton.tintColor = popover.doneButton.color ?? popover.tintColor
         navigationItem.setRightBarButton(doneButton, animated: false)
 
-        // Select row if needed
-        if let select = popover?.selectedRow {
-            picker?.selectRow(select, inComponent: 0, animated: true)
+        clearButton.setTitle(popover.clearButton.title, for: .normal)
+        if let font = popover.clearButton.font {
+            clearButton.titleLabel?.font = font
         }
+        clearButton.tintColor = popover.clearButton.color ?? popover.tintColor
+        clearButton.isHidden = popover.clearButton.action == nil
+
+        
+        // Select row if needed
+        picker?.selectRow(popover.selectedRow, inComponent: 0, animated: true)
     }
     
     /// Action when tapping done button
@@ -70,6 +79,13 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     /// - Parameter sender: Cancel button
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
         tapped(button: popover?.cancelButton)
+    }
+    
+    /// Action when tapping clear button
+    ///
+    /// - Parameter sender: Clear button
+    @IBAction func tappedClear(_ sender: AnyObject? = nil) {
+        tapped(button: popover?.clearButton)
     }
     
     private func tapped(button: StringPickerPopover.ButtonParameterType?) {

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -31,12 +31,16 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     /// Make the popover properties reflect on this view controller
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
+        // Select row if needed
+        picker?.selectRow(popover.selectedRow, inComponent: 0, animated: true)
+
         // Set up cancel button
         if #available(iOS 11.0, *) { }
         else {
             navigationItem.leftBarButtonItem = nil
             navigationItem.rightBarButtonItem = nil
         }
+
         cancelButton.title = popover.cancelButton.title
         if let font = popover.cancelButton.font {
             cancelButton.setTitleTextAttributes([NSAttributedStringKey.font: font], for: .normal)
@@ -58,13 +62,6 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
         clearButton.tintColor = popover.clearButton.color ?? popover.tintColor
         clearButton.isHidden = popover.clearButton.action == nil
         enableClearButtonIfNeeded()
-
-        // Select row if needed
-        picker?.selectRow(popover.selectedRow, inComponent: 0, animated: true)
-        
-        // 初回のdisabled
-        // FIXME: valueを選択したときにenabledをセットすべし
-        // vcとpopoverの違いで詰まる
     }
     
     private func enableClearButtonIfNeeded() {

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -31,10 +31,6 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     /// Make the popover properties reflect on this view controller
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
-        guard let popover = popover else {
-            return
-        }
-
         // Set up cancel button
         if #available(iOS 11.0, *) { }
         else {
@@ -85,23 +81,20 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     ///
     /// - Parameter sender: Done button
     @IBAction func tappedDone(_ sender: AnyObject? = nil) {
-        tapped(button: popover?.doneButton)
+        tapped(button: popover.doneButton)
     }
     
     /// Action when tapping cancel button
     ///
     /// - Parameter sender: Cancel button
     @IBAction func tappedCancel(_ sender: AnyObject? = nil) {
-        tapped(button: popover?.cancelButton)
+        tapped(button: popover.cancelButton)
     }
     
     /// Action when tapping clear button
     ///
     /// - Parameter sender: Clear button
     @IBAction func tappedClear(_ sender: AnyObject? = nil) {
-        guard let popover = popover else {
-            return
-        }
         let kTargetRow = 0
         picker.selectRow(kTargetRow, inComponent: 0, animated: true)
         enableClearButtonIfNeeded()
@@ -113,8 +106,8 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
     
     private func tapped(button: StringPickerPopover.ButtonParameterType?) {
         let selectedRow = picker.selectedRow(inComponent: 0)
-        if let selectedString = popover?.choices[safe: selectedRow] {
-            button?.action?(popover!, selectedRow, selectedString)
+        if let selectedString = popover.choices[safe: selectedRow] {
+            button?.action?(popover, selectedRow, selectedString)
         }
         dismiss(animated: false, completion: {})
     }
@@ -134,23 +127,17 @@ extension StringPickerPopoverViewController: UIPickerViewDataSource {
     }
     
     public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return popover?.choices.count ?? 0
+        return popover.choices.count
     }
 }
 
 // MARK: - UIPickerViewDelegate
 extension StringPickerPopoverViewController: UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        guard let popover = popover else {
-            return nil
-        }
         return popover.displayStringFor?(popover.choices[row]) ?? popover.choices[row]
     }
     
     public func pickerView(_ pickerView: UIPickerView, attributedTitleForRow row: Int, forComponent component: Int) -> NSAttributedString? {
-        guard let popover = popover else {
-            return nil
-        }
         let attributedResult = NSMutableAttributedString()
         
         if let images = popover.images, let image = images[row] {
@@ -173,13 +160,10 @@ extension StringPickerPopoverViewController: UIPickerViewDelegate {
     
     public func pickerView(_ pickerView: UIPickerView,
                            rowHeightForComponent component: Int) -> CGFloat {
-        return popover?.rowHeight ?? 0
+        return popover.rowHeight
     }
     
     public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        guard let popover = popover else {
-            return
-        }
         enableClearButtonIfNeeded()
         popover.valueChangeAction?(popover, row, popover.choices[row])
         popover.redoDisappearAutomatically()


### PR DESCRIPTION
6.5.0 Release notes (2018-05-27)
=============================================================

### API Breaking Changes

* Nothing

### Enhancements

* Add: setClearButton() to String/ColumnStringPickerPopover.

### Bugfixes

* Fix: setSelectedRow/Rows() don't work correctly.
