### PR TITLE
Fix for date picker in dark mode in ios 13

### DIFF
--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -16,7 +16,15 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
     @IBOutlet weak private var cancelButton: UIBarButtonItem!
     @IBOutlet weak private var doneButton: UIBarButtonItem!
     @IBOutlet weak private var clearButton: UIButton!
-    
+
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemBackground
+        }
+    }
+
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
         if #available(iOS 11.0, *) { }


### PR DESCRIPTION
Inspired by https://github.com/hsylife/SwiftyPickerPopover/issues/115
But I didn’t put it at the abstract level as it breaks the other demo examples