### PR TITLE
add ability to specify time zone for DatePickerPopover

### DIFF
--- a/SwiftyPickerPopover/DatePickerPopover.swift
+++ b/SwiftyPickerPopover/DatePickerPopover.swift
@@ -40,6 +40,8 @@ public class DatePickerPopover: AbstractPopover {
     /// Selected date
     private(set) var selectedDate: ItemType = ItemType()
     private(set) var locale: Locale = Locale.current
+    /// Time Zone
+    private(set) var timeZone_: TimeZone = TimeZone.current
     
     // MARK: - Initializer
     
@@ -68,6 +70,13 @@ public class DatePickerPopover: AbstractPopover {
     /// - Returns: self
     public func setDateMode(_ dateMode: UIDatePicker.Mode)->Self{
         self.dateMode_ = dateMode
+        return self
+    }
+    
+    /// Set the time zone for pciker
+    /// - Parameter timeZoneParam: Time zone for pciker
+    public func setTimeZone(_ timeZone: TimeZone)->Self{
+        self.timeZone_ = timeZone
         return self
     }
     
@@ -183,5 +192,5 @@ public class DatePickerPopover: AbstractPopover {
     public func setValueChange(action: ActionHandlerType?)->Self{
         valueChangeAction = action
         return self
-    }    
+    }
 }

--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -49,6 +49,7 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
         picker.minimumDate = popover.minimumDate
         picker.maximumDate = popover.maximumDate
         picker.datePickerMode = popover.dateMode_
+        picker.timeZone = popover.timeZone_
         picker.locale = popover.locale
         if picker.datePickerMode != .date {
             picker.minuteInterval = popover.minuteInterval


### PR DESCRIPTION
Adds ability to specify the time zone for `DatePickerPopover`. I found it necessary in the [TimeConverter](https://github.com/urwrstkn8mare/TimeConverter) app I was making. 