### PR TITLE
Allow multiple lines in StringPickerPopover

### DIFF
--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -38,6 +38,8 @@ public class StringPickerPopover: AbstractPopover {
     private(set) var fontSize: CGFloat?
     let kDefaultFontSize: CGFloat = 14
     
+    private(set) var numberOfLines: Int = 1
+    
     /// Convert a raw value to the string for displaying it
     private(set) var displayStringFor: DisplayStringForType?
     
@@ -80,6 +82,17 @@ public class StringPickerPopover: AbstractPopover {
         self.font = font
         return self
     }
+    
+    
+    /// Set numberOfLines
+    ///
+    /// - Parameter numberOfLines: Int how many lines is needed per row
+    /// - Returns: Self
+    public func setNumberOfLines(_ numberOfLines: Int) -> Self {
+        self.numberOfLines = numberOfLines
+        return self
+    }
+    
     
     public func setFontSize(_ size: CGFloat) -> Self {
         self.fontSize = size

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -144,6 +144,7 @@ extension StringPickerPopoverViewController: UIPickerViewDelegate {
         label.text = adjustedValue
         label.attributedText = getAttributedText(image: popover.images?[row], text: adjustedValue)
         label.textAlignment = .center
+        label.numberOfLines = popover.numberOfLines
         return label
     }
     


### PR DESCRIPTION
I've found that you can't have multiline strings in the rows.
This pr adds a function to specify a number of lines.

Example:

```
    let picker = StringPickerPopover(title: "New Picker", choices: ["One", "Two", "Three very long line description that goes to second line or something else"])
    .setSelectedRow(0)
    .setNumberOfLines(0)
    .setDoneButton(action: { (popover, selectedRow, selectedString) in
        print("done row \(selectedRow) \(selectedString)")
    })
    .setCancelButton(action: { (_, _, _) in print("cancel")})
```