### PR TITLE
Added option to select UIDatePickerStyle introduced in iOS 14

### DIFF
--- a/SwiftyPickerPopover/DatePickerPopover.swift
+++ b/SwiftyPickerPopover/DatePickerPopover.swift
@@ -46,7 +46,7 @@ public class DatePickerPopover: AbstractPopover {
         case compact
         case inline
     }
-    private(set) var preferredDatePickerStyle: PopoverDatePickerStyle = .wheels
+    private(set) var preferredDatePickerStyle: PopoverDatePickerStyle = .automatic
     
     // MARK: - Initializer
     

--- a/SwiftyPickerPopover/DatePickerPopover.swift
+++ b/SwiftyPickerPopover/DatePickerPopover.swift
@@ -40,6 +40,13 @@ public class DatePickerPopover: AbstractPopover {
     /// Selected date
     private(set) var selectedDate: ItemType = ItemType()
     private(set) var locale: Locale = Locale.current
+    public enum PopoverDatePickerStyle {
+        case wheels
+        case automatic
+        case compact
+        case inline
+    }
+    private(set) var preferredDatePickerStyle: PopoverDatePickerStyle = .wheels
     
     // MARK: - Initializer
     
@@ -113,6 +120,15 @@ public class DatePickerPopover: AbstractPopover {
     /// - Returns: Self
     public func setLocale(_ locale:Locale)->Self{
         self.locale = locale
+        return self
+    }
+    
+    /// Set Preferred Date Picker - only works on iOS 13.4 and above
+    ///
+    /// - Parameter style: PopoverDatePickerStyle which is used to display date picker
+    /// - Returns: Self
+    public func setPreferredDatePickerStyle(_ style:PopoverDatePickerStyle)->Self{
+        self.preferredDatePickerStyle = style
         return self
     }
 

--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -50,6 +50,20 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
         picker.maximumDate = popover.maximumDate
         picker.datePickerMode = popover.dateMode_
         picker.locale = popover.locale
+        if #available(iOS 13.4, *) {
+            switch popover.preferredDatePickerStyle {
+            case .wheels:
+                picker.preferredDatePickerStyle = UIDatePickerStyle.wheels
+            case .automatic:
+                picker.preferredDatePickerStyle = UIDatePickerStyle.automatic
+            case .compact:
+                picker.preferredDatePickerStyle = UIDatePickerStyle.compact
+            case .inline:
+                if #available(iOS 14.0, *) {
+                    picker.preferredDatePickerStyle = UIDatePickerStyle.automatic
+                }
+            }
+        }
         if picker.datePickerMode != .date {
             picker.minuteInterval = popover.minuteInterval
         }

--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -60,7 +60,7 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
                 picker.preferredDatePickerStyle = UIDatePickerStyle.compact
             case .inline:
                 if #available(iOS 14.0, *) {
-                    picker.preferredDatePickerStyle = UIDatePickerStyle.automatic
+                    picker.preferredDatePickerStyle = UIDatePickerStyle.inline
                 }
             }
         }


### PR DESCRIPTION
Added function `setPreferredDatePickerStyle` which accepts a PopoverDatePickerStyle enumeration with these options:

- wheels

- automatic

- compact

- inline

Only available from iOS 13.4 and above. Lower OS versions just use the default date picker style