### PR TITLE
rendering the datepicker correctly for iOS 14+

### DIFF
--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -53,6 +53,13 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
         if picker.datePickerMode != .date {
             picker.minuteInterval = popover.minuteInterval
         }
+
+        if #available(iOS 13.4, *) {
+            picker.preferredDatePickerStyle = .wheels
+        } else {
+            // Fallback on earlier versions
+        }
+        
     }
 
     @IBAction func tappedDone(_ sender: UIButton? = nil) {


### PR DESCRIPTION
The UIDatePicker is rendering incorrectly for devices that run on iOS 14+, this patch makes it at least show up as wheels by default.